### PR TITLE
Reimplement target_ids, refactoring and use yaml not csv to set attribute field

### DIFF
--- a/config/dataset/README.md
+++ b/config/dataset/README.md
@@ -1,0 +1,78 @@
+# Dataset config
+
+## Dataset-wide configuration
+
+### Input dimensions and overlap
+
+These parameters respectively set the width and length of a single sample and stride from one sample to another as
+outputted by sampling_segmentation.py. Default to 256 and 0, respectively.
+
+### Train/validation percentage
+
+This parameters sets the proportion of samples that should be selected for each dataset. Total should be 1. Trn/val
+percentages default to 0.7/0.3.
+
+> The "tst" dataset percentage is currently not implemented. AOIs meant to be part of test dataset should be tagged
+> "tst" in the last column of [the input csv](https://github.com/NRCan/geo-deep-learning/blob/develop/data/images_to_samples_ci_csv.csv).
+
+
+### Stratification bias
+
+This feature's documentation is a work in progress. Stratification bias was implemented in [PR #204]
+(https://github.com/NRCan/geo-deep-learning/pull/204)
+For more information on the concept of stratified sampling, see [this Medium article]
+(https://medium.com/analytics-vidhya/stratified-sampling-in-machine-learning-f5112b5b9cfe)
+
+### Raw data directory and csv
+
+[WIP]
+
+## Imagery
+
+### Modalities
+
+Bands to be selected during the sampling process. Order matters (ie "BGR" is not equal to "RGB").
+The use of this feature for band selection is a work in progress. It currently serves to indicate how many bands are in
+source imagery.
+
+## Ground truth (polygon features)
+
+### "Attribute_field" & "Attribute_values": filter ground truth data with
+
+Parameters "attribute_field" and "attribute_values" aim to filter only relevant classes from the ground truth data.
+They both default to None.
+
+For example, if a ground truth GeoPackage contains polygons belonging to 4 classes of interests (forests, waterbodies,
+roads, buildings), a user can filter out all non-building polygon by choosing an attribute field and value that
+separate building polygons from others. For example:
+
+```yaml
+dataset:
+ ...
+ attribute_field: "4-Class"
+ attribute_values: 4
+```
+
+> Though attribute values may not be continuous numbers starting at 1 (0 being background), Geo-deep-learning ensures
+> all values during training are continuous and, therefore, match values from predictions.
+
+### Minimum annotated percent
+
+Minimum % of non background pixels in label in order to add sample to final training dataset. Defaults to 0.
+
+### class_name, classes_dict, class_weights
+
+[WIP]
+
+### Ignore_index
+
+Specifies a target value that is ignored and does not contribute to the input gradient. Defaults to None.
+
+## Output
+
+### Samples data directory
+
+Sets the path to the directory where samples will be written.
+
+
+

--- a/config/dataset/test_ci_segmentation_dataset.yaml
+++ b/config/dataset/test_ci_segmentation_dataset.yaml
@@ -1,17 +1,26 @@
 # @package _global_
 dataset:
+  # dataset-wide
   name:
-  modalities: RGB
   input_dim: 256
   overlap:
-  min_annot_perc:
+  use_stratification: False
+  train_val_percent: {'trn':0.7, 'val':0.3, 'tst':0}
   raw_data_csv: ${general.raw_data_csv}
   raw_data_dir: ${general.raw_data_dir}
-  sample_data_dir: ${general.sample_data_dir}
+
+  # imagery
+  modalities: RGB
+
+  # ground truth
+  attribute_field: properties/class
+  attribute_values: [1]
+  min_annot_perc:
   class_name: # will follow in the next version
   classes_dict: {'Building':1}
   class_weights:
-  train_val_percent: {'trn':0.7, 'val':0.2, 'tst':0.1}
   ignore_index:
-  use_stratification: False
+
+  # outputs
+  sample_data_dir: ${general.sample_data_dir}
 

--- a/data/images_to_samples_ci_csv.csv
+++ b/data/images_to_samples_ci_csv.csv
@@ -1,2 +1,2 @@
-./data/22978945_15.tif,,./data/massachusetts_buildings.gpkg,properties/class,trn
-./data/23429155_15.tif,,./data/massachusetts_buildings.gpkg,properties/class,tst
+./data/22978945_15.tif,,./data/massachusetts_buildings.gpkg,,trn
+./data/23429155_15.tif,,./data/massachusetts_buildings.gpkg,,tst

--- a/sample_creation.py
+++ b/sample_creation.py
@@ -109,7 +109,7 @@ def process_vector_label(rst_pth, gpkg_pth, ids):
                                         out_shape=(src.height, src.width),
                                         attribute_name='properties/Quatreclasses',
                                         fill=0,
-                                        target_ids=ids,
+                                        attribute_values=ids,
                                         merge_all=True,
                                         )
         return np_label

--- a/utils/geoutils.py
+++ b/utils/geoutils.py
@@ -102,14 +102,14 @@ def clip_raster_with_gpkg(raster, gpkg, debug=False):
             warnings.warn(f"e\n {raster.name}\n{gpkg}")
 
 
-def vector_to_raster(vector_file, input_image, out_shape, attribute_name, fill=0, target_ids=None, merge_all=True):
+def vector_to_raster(vector_file, input_image, out_shape, attribute_name, fill=0, attribute_values=None, merge_all=True):
     """Function to rasterize vector data.
     Args:
         vector_file: Path and name of reference GeoPackage
         input_image: Rasterio file handle holding the (already opened) input raster
         attribute_name: Attribute containing the identifier for a vector (may contain slashes if recursive)
         fill: default background value to use when filling non-contiguous regions
-        target_ids: list of identifiers to burn from the vector file (None = use all)
+        attribute_values: list of identifiers to burn from the vector file (None = use all)
         merge_all: defines whether all vectors should be burned with their identifiers in a
             single layer or in individual layers (in the order provided by 'target_ids')
 
@@ -124,12 +124,11 @@ def vector_to_raster(vector_file, input_image, out_shape, attribute_name, fill=0
     if attribute_name is not None:
         lst_vector.sort(key=lambda vector: get_key_recursive(attribute_name, vector))
 
-    lst_vector_tuple = lst_ids(list_vector=lst_vector, attr_name=attribute_name, target_ids=target_ids,
+    lst_vector_tuple = lst_ids(list_vector=lst_vector, attr_name=attribute_name, target_ids=attribute_values,
                                merge_all=merge_all)
 
-    if not lst_vector_tuple:  # if no vectors found, return None and prevent error in rasterize function below.
-        logging.warning()
-        return None
+    if not lst_vector_tuple:
+        raise ValueError("No vector features found")
     elif merge_all:
         np_label_raster = rasterio.features.rasterize([v for vecs in lst_vector_tuple.values() for v in vecs],
                                            fill=fill,
@@ -145,9 +144,12 @@ def vector_to_raster(vector_file, input_image, out_shape, attribute_name, fill=0
         np_label_raster = np.stack(burned_rasters, axis=-1)
 
     # overwritte label values to make sure they are continuous
-    if target_ids:
-        for index, target_id in enumerate(target_ids):
-            np_label_raster[np_label_raster == target_id] = (index + 1)
+    if attribute_values:
+        for index, target_id in enumerate(attribute_values):
+            if index+1 == target_id:
+                continue
+            else:
+                np_label_raster[np_label_raster == target_id] = (index + 1)
 
     return np_label_raster
 

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -457,7 +457,12 @@ def read_csv(csv_file_name, data_path=None):
             row[0] = try2read_csv(row[0], data_path, 'Tif raster not found:')
             if row[2]:
                 row[2] = try2read_csv(row[2], data_path, 'Gpkg not found:')
-                assert isinstance(row[3], str)
+            if not isinstance(row[3], str):
+                raise ValueError(f"Attribute name should be a string")
+            if row[3] is not "":
+                logging.error(f"Deprecation notice:\nFiltering ground truth features by attribute name and values should"
+                              f" be done through the dataset parameters in config/dataset. The attribute name value in "
+                              f"csv will be ignored. Got: {row[3]}")
             # save all values
             list_values.append(
                 {'tif': row[0], 'meta': row[1], 'gpkg': row[2], 'attribute_name': row[3], 'dataset': row[4]}

--- a/utils/verifications.py
+++ b/utils/verifications.py
@@ -17,7 +17,7 @@ def validate_num_classes(vector_file: Union[str, Path],
                          num_classes: int,
                          attribute_name: str,
                          ignore_index: int,
-                         target_ids: List):
+                         attribute_values: List):
     """Check that `num_classes` is equal to number of classes detected in the specified attribute for each GeoPackage.
     FIXME: this validation **will not succeed** if a Geopackage contains only a subset of `num_classes` (e.g. 3 of 4).
     Args:
@@ -26,7 +26,7 @@ def validate_num_classes(vector_file: Union[str, Path],
         :param attribute_name: name of the value field representing the required classes in the vector image file
         :param ignore_index: (int) target value that is ignored during training and does not contribute to
                              the input gradient
-        :param target_ids: list of identifiers to burn from the vector file (None = use all)
+        :param attribute_values: list of identifiers to burn from the vector file (None = use all)
     Return:
         List of unique attribute values found in gpkg vector file
     """
@@ -45,15 +45,15 @@ def validate_num_classes(vector_file: Union[str, Path],
         unique_att_vals.remove(ignore_index)
 
     # if burning a subset of gpkg's classes
-    if target_ids:
-        if not len(target_ids) == num_classes:
+    if attribute_values:
+        if not len(attribute_values) == num_classes:
             raise ValueError(f'Yaml parameters mismatch. \n'
-                             f'Got target_ids {target_ids} (sample sect) with length {len(target_ids)}. '
+                             f'Got values {attribute_values} (sample sect) with length {len(attribute_values)}. '
                              f'Expected match with num_classes {num_classes} (global sect))')
         # make sure target ids are a subset of all attribute values in gpkg
-        if not set(target_ids).issubset(unique_att_vals):
+        if not set(attribute_values).issubset(unique_att_vals):
             logging.warning(f'\nFailed scan of vector file: {vector_file}\n'
-                            f'\tExpected to find all target ids {target_ids}. \n'
+                            f'\tExpected to find all target ids {attribute_values}. \n'
                             f'\tFound {unique_att_vals} for attribute "{attribute_name}"')
     else:
         # this can happen if gpkg doens't contain all classes, thus the warning rather than exception


### PR DESCRIPTION
reimplement target_ids
rename target_ids to attribute_values (more meaningful in GIS vocabulary: attribute table, attribute field, attribute values, etc.)
move attribute field input from csv to yaml
add documentation for dataset configuration

closes #251 