### PR TITLE
Refactor path management and restore some interface usage to pre #208

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -76,20 +76,19 @@ The chosen `yaml` from the task categories will gather all the parameters releva
 #### General Section
 ```YAML
 general:
-  work_dir: ${hydra:runtime.cwd}
+  work_dir: ${hydra:runtime.cwd}  # where the code is executed
   config_name: ${hydra:job.config_name}
   config_override_dirname: ${hydra:job.override_dirname}
   config_path: ${hydra:runtime.config_sources}
   project_name: template_project
   workspace: your_name
-  device: cuda
   max_epochs: 2 # for train only
   min_epochs: 1 # for train only
-  raw_data_dir: ${general.work_dir}/data
-  raw_data_csv: ${general.work_dir}/data/images_to_samples_ci_csv.csv
-  sample_data_dir: ${general.work_dir}/data
+  raw_data_dir: data
+  raw_data_csv: data/images_to_samples_ci_csv.csv
+  sample_data_dir: data # where the hdf5 will be saved
   state_dict_path:
-  save_weights_dir: ${general.work_dir}/weights_saved
+  save_weights_dir: saved_model/${general.project_name}
 ```
 This section contains general information that will be read by the code. Other `yaml` files read information from here.
 
@@ -101,7 +100,7 @@ If `True`, will save the config in the log folder.
 
 #### Mode Section
 ```YAML
-mode: {sampling, train, evaluate, inference, hyperparameters_search}
+mode: {sampling, train, inference, evaluate, hyperparameters_search}
 ```
 **GDL** has five modes: sampling, train, evaluate, inference and hyperparameters search.
 - *sampling*, generates `hdf5` files from a folder containing folders for each individual image with their ground truth.

--- a/config/gdl_config_template.yaml
+++ b/config/gdl_config_template.yaml
@@ -27,14 +27,13 @@ general:
   config_path: ${hydra:runtime.config_sources}
   project_name: template_project
   workspace: your_name
-  device: cuda
   max_epochs: 2 # for train only
   min_epochs: 1 # for train only
-  raw_data_dir: ${general.work_dir}/data
-  raw_data_csv: ${general.work_dir}/data/images_to_samples_ci_csv.csv
-  sample_data_dir: ${general.work_dir}/data # where the hdf5 will be saved
+  raw_data_dir: data
+  raw_data_csv: data/images_to_samples_ci_csv.csv
+  sample_data_dir: data # where the hdf5 will be saved
   state_dict_path:
-  save_weights_dir: ${general.work_dir}/weights_saved
+  save_weights_dir: saved_model/${general.project_name}
 
 AWS:
   bucket_name:

--- a/config/inference/default_inference.yaml
+++ b/config/inference/default_inference.yaml
@@ -1,7 +1,7 @@
 # @package _global_
 inference:
-  img_dir_or_csv_file: ${general.work_dir}/data/inference_sem_seg_ci_csv.csv
-  state_dict_path: ${general.save_weights_dir}
+  img_dir_or_csv_file: data/inference_sem_seg_ci_csv.csv
+  state_dict_path: ${general.save_weights_dir}/checkpoint.pth.tar
   chunk_size: 256
   # Visualization parameters
   smooth_prediction: True

--- a/data/images_to_samples_ci_csv.csv
+++ b/data/images_to_samples_ci_csv.csv
@@ -1,2 +1,2 @@
-./22978945_15_uint8_clipped.tif,,./massachusetts_buildings.gpkg,,trn
-./23429155_15_uint8_clipped.tif,,./massachusetts_buildings.gpkg,,tst
+data/22978945_15_uint8_clipped.tif,,data/massachusetts_buildings.gpkg,,trn
+data/23429155_15_uint8_clipped.tif,,data/massachusetts_buildings.gpkg,,tst

--- a/data/inference_sem_seg_ci_csv.csv
+++ b/data/inference_sem_seg_ci_csv.csv
@@ -1,1 +1,1 @@
-./23429155_15_uint8_inf.tif,,./massachusetts_buildings.gpkg,,tst
+data/23429155_15_uint8_inf.tif,,data/massachusetts_buildings.gpkg,,tst

--- a/evaluate_segmentation.py
+++ b/evaluate_segmentation.py
@@ -77,12 +77,12 @@ def main(params):
     @return:
     """
     start_seg = time.time()
-    state_dict = Path(params['inference']['state_dict_path']).resolve(strict=True)
+    state_dict = get_key_def('state_dict_path', params['inference'], to_path=True, validate_path_exists=True)
     modalities = read_modalities(get_key_def('modalities', params['dataset'], expected_type=str))
     num_bands = len(modalities)
     working_folder = state_dict.parent.joinpath(f'inference_{num_bands}bands')
-    img_dir_or_csv = get_key_def('img_dir_or_csv_file', params['inference'], default=params['general']['raw_data_csv'],
-                                 expected_type=str)
+    img_dir_or_csv = get_key_def('img_dir_or_csv_file', params['inference'], expected_type=str, to_path=True,
+                                 validate_path_exists=True)
     num_classes = len(get_key_def('classes_dict', params['dataset']).keys())
     single_class_mode = True if num_classes == 1 else False
     threshold = 0.5
@@ -92,7 +92,7 @@ def main(params):
     out_gpkg = get_key_def('out_benchmark_gpkg', params['inference'], default=working_folder/"benchmark.gpkg",
                            expected_type=str)
     chunk_size = get_key_def('chunk_size', params['inference'], default=512, expected_type=int)
-    dontcare = get_key_def("ignore_index", params["training"], -1)
+    dontcare = get_key_def("ignore_index", params["dataset"], -1)
     attribute_field = get_key_def('attribute_field', params['dataset'], None, expected_type=str)
     attr_vals = get_key_def('attribute_values', params['dataset'], None, expected_type=Sequence)
 
@@ -102,8 +102,7 @@ def main(params):
             if not isinstance(item, int):
                 raise ValueError(f'\nValue "{item}" in attribute_values is {type(item)}, expected int.')
 
-    list_img = list_input_images(img_dir_or_csv, glob_patterns=["*.tif", "*.TIF"],
-                                 in_case_of_path=Path(get_original_cwd())/'data')
+    list_img = list_input_images(img_dir_or_csv, glob_patterns=["*.tif", "*.TIF"])
 
     # VALIDATION: anticipate problems with imagery and label (if provided) before entering main for loop
     valid_gpkg_set = set()

--- a/evaluate_segmentation.py
+++ b/evaluate_segmentation.py
@@ -14,7 +14,8 @@ import geopandas as gpd
 
 from utils.geoutils import clip_raster_with_gpkg, vector_to_raster
 from utils.metrics import ComputePixelMetrics
-from utils.utils import get_key_def, list_input_images, get_logger, read_modalities
+from utils.utils import get_key_def, list_input_images, read_modalities
+from utils.logger import get_logger
 from utils.verifications import validate_num_classes, assert_crs_match
 
 logging = get_logger(__name__)

--- a/gdl_hyperopt_template.py
+++ b/gdl_hyperopt_template.py
@@ -13,12 +13,12 @@ from functools import partial
 import pprint
 import numpy as np
 
+from ruamel_yaml import YAML
 import mlflow
 import torch
 # ToDo: Add hyperopt to GDL requirements
 from hyperopt import fmin, tpe, hp, Trials, STATUS_OK
 
-from utils.readers import read_parameters
 from train_segmentation import main as train_main
 
 # This is the hyperparameter space to explore
@@ -26,6 +26,19 @@ my_space = {'model_name': hp.choice('model_name', ['unet_pretrained', 'deeplabv3
             'loss_fn': hp.choice('loss_fn', ['CrossEntropy', 'Lovasz', 'Duo']),
             'optimizer': hp.choice('optimizer', ['adam', 'adabound']),
             'learning_rate': hp.loguniform('learning_rate', np.log(1e-7), np.log(0.1))}
+
+
+def read_parameters(param_file):
+    """Read and return parameters in .yaml file
+    Args:
+        param_file: Full file path of the parameters file
+    Returns:
+        YAML (Ruamel) CommentedMap dict-like object
+    """
+    yaml = YAML()
+    with open(param_file) as yamlfile:
+        params = yaml.load(yamlfile)
+    return params
 
 
 def get_latest_mlrun(params):

--- a/inference_segmentation.py
+++ b/inference_segmentation.py
@@ -25,7 +25,7 @@ from rasterio.plot import reshape_as_image
 from pathlib import Path
 from omegaconf.listconfig import ListConfig
 
-from utils.logger import dict_path
+from utils.logger import dict_path, get_logger
 from models.model_choice import net
 from utils import augmentation
 from utils.utils import load_from_checkpoint, get_device_ids, get_key_def, \
@@ -37,8 +37,7 @@ try:
 except ModuleNotFoundError:
     pass
 # Set the logging file
-from utils import utils
-logging = utils.get_logger(__name__)
+logging = get_logger(__name__)
 
 
 def _pad_diff(arr, w, h, arr_shape):
@@ -460,7 +459,7 @@ def main(params: dict) -> None:
 
     # VALIDATION: anticipate problems with imagery before entering main for loop
     for info in tqdm(list_img, desc='Validating imagery'):
-        validate_raster(info['tif'], num_bands, None)
+        validate_raster(info['tif'], num_bands)
     logging.info('\nSuccessfully validated imagery')
 
     # TODO: Add verifications?

--- a/models/model_choice.py
+++ b/models/model_choice.py
@@ -17,7 +17,7 @@ from tqdm import tqdm
 from utils.optimizer import create_optimizer
 import torch.optim as optim
 from models import TernausNet, unet, checkpointed_unet, inception
-from utils.utils import load_from_checkpoint, get_device_ids, get_key_def
+from utils.utils import load_from_checkpoint, get_device_ids, get_key_def, set_device
 
 logging.getLogger(__name__)
 
@@ -246,8 +246,6 @@ def net(model_name: str,
         # list of GPU devices that are available and unused. If no GPUs, returns empty list
         gpu_devices_dict = get_device_ids(num_devices)
         num_devices = len(gpu_devices_dict.keys())
-        logging.info(f"Number of cuda devices requested: {num_devices}. "
-                     f"Cuda devices available: {list(gpu_devices_dict.keys())}\n")
         if num_devices == 1:
             logging.info(f"\nUsing Cuda device 'cuda:{list(gpu_devices_dict.keys())[0]}'")
         elif num_devices > 1:
@@ -263,13 +261,9 @@ def net(model_name: str,
         else:
             logging.warning(f"No Cuda device available. This process will only run on CPU\n")
         logging.info(f'\nSetting model, criterion, optimizer and learning rate scheduler...')
-        device = torch.device(f'cuda:{list(range(len(gpu_devices_dict.keys())))[0]}' if gpu_devices_dict else 'cpu')
-        try:  # For HPC when device 0 not available. Error: Cuda invalid device ordinal.
-            model.to(device)
-        except AssertionError:
-            logging.exception(f"Unable to use device. Trying device 0...\n")
-            device = torch.device(f'cuda' if gpu_devices_dict else 'cpu')
-            model.to(device)
+
+        device = set_device(gpu_devices_dict=gpu_devices_dict)
+        model.to(device)
 
         model, criterion, optimizer, lr_scheduler = set_hyperparameters(params=net_params,
                                                                         model=model,

--- a/sample_creation.py
+++ b/sample_creation.py
@@ -6,7 +6,6 @@ import numpy as np
 np.random.seed(1234)  # Set random seed for reproducibility
 import warnings
 import rasterio
-import fiona
 import shutil
 import time
 import json
@@ -14,7 +13,7 @@ import json
 from pathlib import Path
 from tqdm import tqdm
 from collections import Counter
-from typing import List, Union
+from typing import List
 from ruamel_yaml import YAML
 
 from utils.create_dataset import create_files_and_datasets

--- a/sample_creation.py
+++ b/sample_creation.py
@@ -15,15 +15,27 @@ from pathlib import Path
 from tqdm import tqdm
 from collections import Counter
 from typing import List, Union
+from ruamel_yaml import YAML
 
 from utils.create_dataset import create_files_and_datasets
 from utils.utils import get_key_def, pad, pad_diff, add_metadata_from_raster_to_sample
 from utils.geoutils import vector_to_raster, clip_raster_with_gpkg
-from utils.readers import read_parameters
 from utils.verifications import assert_crs_match, validate_num_classes
-from rasterio.mask import mask
 from rasterio.windows import Window
 from rasterio.plot import reshape_as_image
+
+
+def read_parameters(param_file):
+    """Read and return parameters in .yaml file
+    Args:
+        param_file: Full file path of the parameters file
+    Returns:
+        YAML (Ruamel) CommentedMap dict-like object
+    """
+    yaml = YAML()
+    with open(param_file) as yamlfile:
+        params = yaml.load(yamlfile)
+    return params
 
 
 def validate_class_prop_dict(actual_classes_dict, config_dict):
@@ -305,8 +317,6 @@ def main(params):
     overlap = params["sample"]["overlap"]
     dist_samples = round(samples_size * (1 - (overlap / 100)))
     min_annot_perc = get_key_def('min_annotated_percent', params['sample']['sampling_method'], None, expected_type=int)
-    ignore_index = get_key_def('ignore_index', params['training'], -1)
-    meta_map = get_key_def('meta_map', params['global'], default={})
 
     list_params = params['read_img']
     source_pan = get_key_def('pan', list_params['source'], default=False, expected_type=bool)
@@ -342,7 +352,6 @@ def main(params):
     Path.mkdir(samples_folder, exist_ok=False)  # TODO: what if we want to append samples to existing hdf5?
     trn_hdf5, val_hdf5, tst_hdf5 = create_files_and_datasets(samples_size=samples_size,
                                                              number_of_bands=num_bands,
-                                                             meta_map=meta_map,
                                                              samples_folder=samples_folder,
                                                              params=params)
 

--- a/sampling_segmentation.py
+++ b/sampling_segmentation.py
@@ -364,11 +364,7 @@ def main(cfg: DictConfig) -> None:
     try:
         import boto3
     except ModuleNotFoundError:
-        logging.warning(
-            "\nThe boto3 library couldn't be imported. Ignore if not using AWS s3 buckets",
-            ImportWarning
-        )
-        pass
+        logging.warning("\nThe boto3 library couldn't be imported. Ignore if not using AWS s3 buckets", ImportWarning)
 
     # PARAMETERS
     num_classes = len(cfg.dataset.classes_dict.keys())

--- a/sampling_segmentation.py
+++ b/sampling_segmentation.py
@@ -22,6 +22,12 @@ from utils.verifications import (
 )
 # Set the logging file
 logging = get_logger(__name__)  # import logging
+
+try:
+    import boto3
+except ModuleNotFoundError:
+    logging.warning("\nThe boto3 library couldn't be imported. Ignore if not using AWS s3 buckets", ImportWarning)
+
 # Set random seed for reproducibility
 np.random.seed(1234)
 
@@ -361,11 +367,6 @@ def main(cfg: DictConfig) -> None:
     -------
     :param cfg: (dict) Parameters found in the yaml config file.
     """
-    try:
-        import boto3
-    except ModuleNotFoundError:
-        logging.warning("\nThe boto3 library couldn't be imported. Ignore if not using AWS s3 buckets", ImportWarning)
-
     # PARAMETERS
     num_classes = len(cfg.dataset.classes_dict.keys())
     num_bands = len(cfg.dataset.modalities)
@@ -373,37 +374,9 @@ def main(cfg: DictConfig) -> None:
     debug = cfg.debug
 
     # RAW DATA PARAMETERS
-    # Data folder
-    try:
-        # check if the folder exist
-        my_data_path = Path(cfg.dataset.raw_data_dir).resolve(strict=True)
-        logging.info("\nImage directory used '{}'".format(my_data_path))
-        data_path = Path(my_data_path)
-    except FileNotFoundError:
-        raise logging.critical(
-            "\nImage directory '{}' doesn't exist, please change the path".format(cfg.dataset.raw_data_dir)
-        )
-    # CSV file
-    try:
-        my_csv_path = Path(cfg.dataset.raw_data_csv).resolve(strict=True)
-        # path.exists(cfg.dataset.raw_data_csv)
-        logging.info("\nImage csv: '{}'".format(my_csv_path))
-        csv_file = my_csv_path
-    except FileNotFoundError:
-        raise logging.critical(
-            "\nImage csv '{}' doesn't exist, please change the path".format(cfg.dataset.raw_data_csv)
-        )
-    # HDF5 data
-    try:
-        my_hdf5_path = Path(str(cfg.dataset.sample_data_dir)).resolve(strict=True)
-        logging.info("\nThe HDF5 directory used '{}'".format(my_hdf5_path))
-        Path.mkdir(Path(my_hdf5_path), exist_ok=True, parents=True)
-    except FileNotFoundError:
-        logging.info(
-            "\nThe HDF5 directory '{}' doesn't exist, please change the path.".format(cfg.dataset.sample_data_dir) +
-            "\nFor now the HDF5 directory use will be change for '{}'".format(data_path)
-        )
-        cfg.general.sample_data_dir = str(data_path)
+    data_path = get_key_def('raw_data_dir', cfg['dataset'], to_path=True, validate_path_exists=True)
+    csv_file = get_key_def('raw_data_csv', cfg['dataset'], to_path=True, validate_path_exists=True)
+    out_path = get_key_def('sample_data_dir', cfg['dataset'], default=data_path, to_path=True, validate_path_exists=True)
 
     # SAMPLE PARAMETERS
     samples_size = get_key_def('input_dim', cfg['dataset'], default=256, expected_type=int)
@@ -412,12 +385,12 @@ def main(cfg: DictConfig) -> None:
     val_percent = get_key_def('train_val_percent', cfg['dataset'], default=0.3)['val'] * 100
     samples_folder_name = f'samples{samples_size}_overlap{overlap}_min-annot{min_annot_perc}' \
                           f'_{num_bands}bands_{cfg.general.project_name}'
-    samples_dir = data_path.joinpath(samples_folder_name)
+    samples_dir = out_path.joinpath(samples_folder_name)
     if samples_dir.is_dir():
         if debug:
             # Move existing data folder with a random suffix.
             last_mod_time_suffix = datetime.fromtimestamp(samples_dir.stat().st_mtime).strftime('%Y%m%d-%H%M%S')
-            shutil.move(samples_dir, data_path.joinpath(f'{str(samples_dir)}_{last_mod_time_suffix}'))
+            shutil.move(samples_dir, out_path.joinpath(f'{str(samples_dir)}_{last_mod_time_suffix}'))
         else:
             logging.critical(
                 f'Data path exists: {samples_dir}. Remove it or use a different experiment_name.'
@@ -436,12 +409,7 @@ def main(cfg: DictConfig) -> None:
     # set dontcare (aka ignore_index) value
     dontcare = cfg.dataset.ignore_index if cfg.dataset.ignore_index is not None else -1
     if dontcare == 0:
-        logging.warning(
-            "\nThe 'dontcare' value (or 'ignore_index') used in the loss function cannot be zero."
-            " All valid class indices should be consecutive, and start at 0. The 'dontcare' value"
-            " will be remapped to -1 while loading the dataset, and inside the config from now on."
-        )
-        dontcare = -1
+        raise ValueError("\nThe 'dontcare' value (or 'ignore_index') used in the loss function cannot be zero.")
     attribute_field = get_key_def('attribute_field', cfg['dataset'], None, expected_type=str)
     # Assert that all items in attribute_values are integers (ex.: single-class samples from multi-class label)
     attr_vals = get_key_def('attribute_values', cfg['dataset'], None, expected_type=Sequence)
@@ -474,9 +442,9 @@ def main(cfg: DictConfig) -> None:
         s3 = boto3.resource('s3')
         bucket = s3.Bucket(bucket_name)
         bucket.download_file(csv_file, 'samples_prep.csv')
-        list_data_prep = read_csv('samples_prep.csv', data_path)
+        list_data_prep = read_csv('samples_prep.csv')
     else:
-        list_data_prep = read_csv(csv_file, data_path)
+        list_data_prep = read_csv(csv_file)
 
     # IF DEBUG IS ACTIVATE
     if debug:

--- a/train_segmentation.py
+++ b/train_segmentation.py
@@ -21,12 +21,11 @@ except ModuleNotFoundError:
 from torch.utils.data import DataLoader
 from sklearn.utils import compute_sample_weight
 from utils import augmentation as aug, create_dataset
-from utils.logger import InformationLogger, save_logs_to_bucket, tsv_line, dict_path, get_logger
+from utils.logger import InformationLogger, save_logs_to_bucket, tsv_line, dict_path, get_logger, set_tracker
 from utils.metrics import report_classification, create_metrics_dict, iou
 from models.model_choice import net, load_checkpoint, verify_weights
 from utils.utils import load_from_checkpoint, gpu_stats, get_key_def, read_modalities
 from utils.visualization import vis_from_batch
-from mlflow import log_params, set_tracking_uri, set_experiment, start_run
 # Set the logging file
 logging = get_logger(__name__)  # import logging
 
@@ -520,18 +519,10 @@ def train(cfg: DictConfig) -> None:
     max_used_ram = get_key_def('max_used_ram', cfg['training'], default=15)
     max_used_perc = get_key_def('max_used_perc', cfg['training'], default=15)
 
-    # LOGGING PARAMETERS TODO put option not just mlflow
+    # LOGGING PARAMETERS
+    run_name = get_key_def(['tracker', 'run_name'], cfg, default='gdl')
+    tracker_uri = get_key_def(['tracker', 'uri'], cfg, default=None, expected_type=str)
     experiment_name = get_key_def('project_name', cfg['general'], default='gdl-training')
-    try:
-        tracker_uri = get_key_def('uri', cfg['tracker'])
-        Path(tracker_uri).mkdir(exist_ok=True)
-        run_name = get_key_def('run_name', cfg['tracker'], default='gdl')  # TODO change for something meaningful
-    # meaning no logging tracker as been assigned or it doesnt exist in config/logging
-    except ConfigKeyError:
-        logging.info(
-            "\nNo logging tracker as been assigned or the yaml config doesnt exist in 'config/tracker'."
-            "\nNo tracker file will be saved in this case."
-        )
 
     # PARAMETERS FOR hdf5 SAMPLES
     # info on the hdf5 name
@@ -634,25 +625,11 @@ def train(cfg: DictConfig) -> None:
                                                                        calc_eval_bs=calc_eval_bs,
                                                                        debug=debug)
 
-    # Save tracking TODO put option not just mlflow
-    if 'tracker_uri' in locals() and 'run_name' in locals():
-        mode = get_key_def('mode', cfg, expected_type=str)
-        task = get_key_def('task_name', cfg['task'], expected_type=str)
-        run_name = '{}_{}_{}'.format(run_name, mode, task)
-        # tracking path + parameters logging
-        set_tracking_uri(tracker_uri)
-        set_experiment(experiment_name)
-        start_run(run_name=run_name)
-        log_params(dict_path(cfg, 'training'))
-        log_params(dict_path(cfg, 'dataset'))
-        log_params(dict_path(cfg, 'model'))
-        log_params(dict_path(cfg, 'optimizer'))
-        log_params(dict_path(cfg, 'scheduler'))
-        log_params(dict_path(cfg, 'augmentation'))
-        # TODO change something to not only have the mlflow option
-        trn_log = InformationLogger('trn')
-        val_log = InformationLogger('val')
-        tst_log = InformationLogger('tst')
+    # Save tracking
+    set_tracker(mode='train', type='mlflow', task='segmentation', experiment_name=experiment_name, run_name=run_name,
+                tracker_uri=tracker_uri, params=cfg,
+                keys2log=['general', 'training', 'dataset', 'model', 'optimizer', 'scheduler', 'augmentation'])
+    trn_log, val_log, tst_log = [InformationLogger(dataset) for dataset in ['trn', 'val', 'tst']]
 
     if bucket_name:
         from utils.aws import download_s3_files

--- a/train_segmentation.py
+++ b/train_segmentation.py
@@ -224,14 +224,8 @@ def vis_from_dataloader(vis_params,
         for batch_index, data in enumerate(_tqdm):
             if vis_batch_range is not None and batch_index in range(min_vis_batch, max_vis_batch, increment):
                 with torch.no_grad():
-                    try:  # For HPC when device 0 not available. Error: RuntimeError: CUDA error: invalid device ordinal
-                        inputs = data['sat_img'].to(device)
-                        labels = data['map_img'].to(device)
-                    except RuntimeError:
-                        logging.exception(f'Unable to use device {device}. Trying "cuda:0"')
-                        device = torch.device('cuda')
-                        inputs = data['sat_img'].to(device)
-                        labels = data['map_img'].to(device)
+                    inputs = data['sat_img'].to(device)
+                    labels = data['map_img'].to(device)
 
                     outputs = model(inputs)
                     if isinstance(outputs, OrderedDict):
@@ -285,14 +279,8 @@ def training(train_loader,
     for batch_index, data in enumerate(tqdm(train_loader, desc=f'Iterating train batches with {device.type}')):
         progress_log.open('a', buffering=1).write(tsv_line(ep_idx, 'trn', batch_index, len(train_loader), time.time()))
 
-        try:  # For HPC when device 0 not available. Error: RuntimeError: CUDA error: invalid device ordinal
-            inputs = data['sat_img'].to(device)
-            labels = data['map_img'].to(device)
-        except RuntimeError:
-            logging.exception(f'Unable to use device {device}. Trying "cuda:0"')
-            device = torch.device('cuda')
-            inputs = data['sat_img'].to(device)
-            labels = data['map_img'].to(device)
+        inputs = data['sat_img'].to(device)
+        labels = data['map_img'].to(device)
 
         # forward
         optimizer.zero_grad()
@@ -382,14 +370,8 @@ def evaluation(eval_loader,
         progress_log.open('a', buffering=1).write(tsv_line(ep_idx, dataset, batch_index, len(eval_loader), time.time()))
 
         with torch.no_grad():
-            try:  # For HPC when device 0 not available. Error: RuntimeError: CUDA error: invalid device ordinal
-                inputs = data['sat_img'].to(device)
-                labels = data['map_img'].to(device)
-            except RuntimeError:
-                logging.exception(f'\nUnable to use device {device}. Trying "cuda"')
-                device = torch.device('cuda')
-                inputs = data['sat_img'].to(device)
-                labels = data['map_img'].to(device)
+            inputs = data['sat_img'].to(device)
+            labels = data['map_img'].to(device)
 
             labels_flatten = flatten_labels(labels)
 

--- a/utils/aws.py
+++ b/utils/aws.py
@@ -1,9 +1,14 @@
-import warnings
 from pathlib import Path
+
+# Set the logging file
+from utils.logger import get_logger
+
+logging = get_logger(__name__)  # import logging
+
 try:
     import boto3
 except ModuleNotFoundError:
-    warnings.warn('The boto3 library counldn\'t be imported. Ignore if not using AWS s3 buckets', ImportWarning)
+    logging.warning('The boto3 library counldn\'t be imported. Ignore if not using AWS s3 buckets', ImportWarning)
     pass
 
 

--- a/utils/data_analysis.py
+++ b/utils/data_analysis.py
@@ -2,11 +2,10 @@ import argparse
 import logging
 import os
 from pathlib import Path
-from typing import List
 
 from utils.utils import get_key_def, read_csv
 from utils.geoutils import vector_to_raster
-from utils.readers import read_parameters, image_reader_as_array
+from utils.readers import image_reader_as_array
 from utils.verifications import validate_num_classes
 import time
 import rasterio
@@ -15,10 +14,24 @@ import numpy as np
 from collections import OrderedDict
 from numpy import genfromtxt
 from tqdm import tqdm
+from ruamel_yaml import YAML
 
 import sampling_segmentation
 
 logging.getLogger(__name__)
+
+
+def read_parameters(param_file):
+    """Read and return parameters in .yaml file
+    Args:
+        param_file: Full file path of the parameters file
+    Returns:
+        YAML (Ruamel) CommentedMap dict-like object
+    """
+    yaml = YAML()
+    with open(param_file) as yamlfile:
+        params = yaml.load(yamlfile)
+    return params
 
 
 def create_csv():

--- a/utils/geoutils.py
+++ b/utils/geoutils.py
@@ -6,7 +6,6 @@ import numpy as np
 
 import fiona
 import os
-import warnings
 import rasterio
 from rasterio.features import is_valid_geom
 from rasterio.mask import mask
@@ -98,8 +97,7 @@ def clip_raster_with_gpkg(raster, gpkg, debug=False):
                 dest.write(out_img)
             return out_tif
         except ValueError as e:  # if gpkg's extent outside raster: "ValueError: Input shapes do not overlap raster."
-            # TODO: warning or exception? if warning, except must be set in images_to_samples
-            warnings.warn(f"e\n {raster.name}\n{gpkg}")
+            logging.error(f"e\n {raster.name}\n{gpkg}")
 
 
 def vector_to_raster(vector_file, input_image, out_shape, attribute_name, fill=0, attribute_values=None, merge_all=True):

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -1,6 +1,10 @@
 import logging
 import os
-from omegaconf import OmegaConf
+from pathlib import Path
+from typing import Union
+
+import mlflow
+from omegaconf import OmegaConf, DictConfig
 from mlflow import log_metric, exceptions
 from pytorch_lightning.utilities import rank_zero_only
 
@@ -97,3 +101,39 @@ def get_logger(name=__name__, level=logging.INFO) -> logging.Logger:
         setattr(logger, level, rank_zero_only(getattr(logger, level)))
 
     return logger
+
+
+def set_tracker(mode: str, type: str = 'mlflow', task: str = 'segmentation', experiment_name: str = 'exp_gdl',
+                run_name: str = 'run_gdl', tracker_uri: str = None, params: Union[dict, DictConfig] = None,
+                keys2log: list = []) -> None:
+    """
+    Sets information to send to tracker such as parameters, metrics, logs, etc.
+    @param mode: execution mode of geo-deep-learning (ex.: 'train')
+    @param type: tracker type. Default to 'mlflow'
+    @param task: execution task of geo-deep-learning. Defaults to 'segmentation'
+    @param experiment_name: Name of experiment being conducted
+    @param run_name: Name of specific run inside experiment being conducted
+    @param tracker_uri: path to directory where tracker searches for information to track and log.
+    @param params: configuration dictionary
+    @param keys2log: list of keys from config dictionary to be logged to tracker
+    @return:
+    """
+    if not tracker_uri:
+        logging.info("\nNo logging tracker has been assigned or the yaml config doesnt exist in 'config/tracker'."
+                     "\nNo tracker file will be save.")
+        return
+    Path(tracker_uri).mkdir(exist_ok=True)
+    run_name = '{}_{}_{}'.format(run_name, mode, task)
+    if type == 'mlflow':
+        from mlflow import log_params, set_tracking_uri, set_experiment, start_run
+        set_tracking_uri(str(tracker_uri))
+        set_experiment(experiment_name)
+        start_run(run_name=run_name)
+        if params and keys2log:
+            for primary_key in keys2log:
+                try:
+                    log_params(dict_path(params, primary_key))
+                except mlflow.exceptions.MlflowException as e:
+                    logging.error(e)
+    else:
+        raise NotImplementedError(f'The tracker {type} is not currently implemented.')

--- a/utils/readers.py
+++ b/utils/readers.py
@@ -2,27 +2,10 @@ import logging
 
 import numpy as np
 import rasterio
-from ruamel_yaml import YAML
-from tqdm import tqdm
-from pathlib import Path
-from skimage import morphology
 
-from utils.geoutils import vector_to_raster, clip_raster_with_gpkg
+from utils.geoutils import clip_raster_with_gpkg
 
 logger = logging.getLogger(__name__)
-
-
-def read_parameters(param_file):
-    """Read and return parameters in .yaml file
-    Args:
-        param_file: Full file path of the parameters file
-    Returns:
-        YAML (Ruamel) CommentedMap dict-like object
-    """
-    yaml = YAML()
-    with open(param_file) as yamlfile:
-        params = yaml.load(yamlfile)
-    return params
 
 
 def image_reader_as_array(input_image,

--- a/utils/verifications.py
+++ b/utils/verifications.py
@@ -67,7 +67,7 @@ def validate_num_classes(vector_file: Union[str, Path],
     return num_classes_
 
 
-def validate_raster(raster_path: Union[str, Path], num_bands: int, meta_map):
+def validate_raster(raster_path: Union[str, Path], num_bands: int):
     """
     Assert number of bands found in raster is equal to desired number of bands
     :param raster_path: (str or Path) path to raster file

--- a/utils/visualization.py
+++ b/utils/visualization.py
@@ -1,7 +1,6 @@
 import logging
 import math
 import re
-import warnings
 from pathlib import Path
 
 import numpy as np
@@ -176,7 +175,7 @@ def vis(vis_params,
 
     if inference_input_path is not None:
         if debug and len(np.unique(output_acv)) == 1:
-            warnings.warn(f'Inference contains only {np.unique(output_acv)} value. Make sure data scale '
+            logging.warning(f'Inference contains only {np.unique(output_acv)} value. Make sure data scale '
                           f'{scale} is identical with scale used for training model.')
         output_name = vis_path.joinpath(f"{inference_input_path.stem}_inference.tif")
         create_new_raster_from_base(inference_input_path, output_name, output_acv)


### PR DESCRIPTION
partially closes #265 

- use get_key_def() to validate path existence and to convert to a pathlib.Path object
- remove tr2read_csv
- use hydra's to_absolute_path utils (remove calls to ${hydra:runtime.cwd} in yamls
- revert usage of paths to before PR #208 (remove error-handling, remove find_first_file(), set unique model directory at train)