### PR TITLE
fix a bug on calling  the dontcare value in dataset

### DIFF
--- a/train_segmentation.py
+++ b/train_segmentation.py
@@ -90,6 +90,7 @@ def create_dataloader(samples_folder: Path,
 
     for subset in ["trn", "val", "tst"]:
         datasets.append(dataset_constr(samples_folder, subset, num_bands,
+                                       dontcare=dontcare_val,
                                        max_sample_count=num_samples[subset],
                                        radiom_transform=aug.compose_transforms(params=cfg,
                                                                                dataset=subset,

--- a/utils/create_dataset.py
+++ b/utils/create_dataset.py
@@ -66,6 +66,7 @@ class SegmentationDataset(Dataset):
     def __init__(self, work_folder,
                  dataset_type,
                  num_bands,
+                 dontcare=255,
                  max_sample_count=None,
                  radiom_transform=None,
                  geom_transform=None,
@@ -76,6 +77,7 @@ class SegmentationDataset(Dataset):
         self.max_sample_count = max_sample_count
         self.dataset_type = dataset_type
         self.num_bands = num_bands
+        self.dontcare = dontcare
         self.metadata = []
         self.radiom_transform = radiom_transform
         self.geom_transform = geom_transform


### PR DESCRIPTION
Fixing a bug about the `dontcare` value from the segmentation dataset, this value is call in [train_segmentation](https://github.com/NRCan/geo-deep-learning/blob/develop/train_segmentation.py) line [411](https://github.com/NRCan/geo-deep-learning/blob/37cd99dc016df873ef363a1092e41e01b50eff42/train_segmentation.py#L411) and [416](https://github.com/NRCan/geo-deep-learning/blob/37cd99dc016df873ef363a1092e41e01b50eff42/train_segmentation.py#L416). The value was not set in the dataset I presume it was remove in an other PR and the code didn't follow, but this value is needed if we want to have the `iou` and  the `report_classification` save in mlflow or other trackers. 