### PR TITLE
refactor model_choice.py using solution in issue #292 and more

### DIFF
--- a/config/gdl_config_template.yaml
+++ b/config/gdl_config_template.yaml
@@ -32,7 +32,6 @@ general:
   raw_data_dir: data
   raw_data_csv: tests/sampling/sampling_segmentation_binary_ci.csv
   sample_data_dir: data # where the hdf5 will be saved
-  state_dict_path:
   save_weights_dir: saved_model/${general.project_name}
 
 AWS:

--- a/config/model/deeplabv3_resnet101_dualhead.yaml
+++ b/config/model/deeplabv3_resnet101_dualhead.yaml
@@ -1,5 +1,6 @@
 # @package _global_
 model:
   model_name: deeplabv3_resnet101_dualhead
+  conc_point: conv1
   pretrained: True
   

--- a/config/training/default_training.yaml
+++ b/config/training/default_training.yaml
@@ -11,7 +11,8 @@ training:
   mode: 'min'            # 'min' or 'max', will minimize or maximize the chosen metric
   max_used_ram:
   max_used_perc:
-  target_size:
+  state_dict_path:
+  state_dict_strict_load: True
 
 #  precision: 16
 #  step_size: 4

--- a/models/model_choice.py
+++ b/models/model_choice.py
@@ -197,7 +197,7 @@ def define_model(
         model_name,
         num_bands,
         num_classes,
-        dropout_prob,
+        dropout_prob: float = 0.5,
         conc_point: str = None,
         main_device: str = 'cpu',
         devices: List = [],

--- a/models/model_choice.py
+++ b/models/model_choice.py
@@ -1,21 +1,13 @@
-from typing import Sequence
-
+from collections import OrderedDict
+from typing import Union, List
 import logging
+
+import segmentation_models_pytorch as smp
 import torch
 import torch.nn as nn
-import segmentation_models_pytorch as smp
-import torchvision.models as models
-###############################
-from hydra.utils import instantiate
-from segmentation_models_pytorch import DeepLabV3
 
 from models.deeplabv3_dualhead import DeepLabV3_dualhead
-###############################
-from tqdm import tqdm
-from utils.optimizer import create_optimizer
-import torch.optim as optim
 from models import unet, checkpointed_unet
-from utils.utils import load_from_checkpoint, get_device_ids, get_key_def, set_device
 
 logging.getLogger(__name__)
 
@@ -69,106 +61,17 @@ except AttributeError:
     logging.exception("Couldn't load MAnet from segmentation models pytorch package. Check installed version")
 
 
-def load_checkpoint(filename):
+def define_model_architecture(
+    model_name: str,
+    num_bands: int,
+    num_channels: int,
+    dropout_prob: float = False,
+    conc_point: str = None,
+):
     """
-    Loads checkpoint from provided path
-    :param filename: path to checkpoint as .pth.tar or .pth
-    :return: (dict) checkpoint ready to be loaded into model instance
+    Define the model architecture from config parameters
     """
-    try:
-        logging.info(f"\n=> loading model '{filename}'")
-        # For loading external models with different structure in state dict.
-        # May cause problems when trying to load optimizer
-        checkpoint = torch.load(filename, map_location='cpu')
-        if 'model' not in checkpoint.keys():
-            temp_checkpoint = {}
-            # Place entire state_dict inside 'model' key
-            temp_checkpoint['model'] = {k: v for k, v in checkpoint.items()}
-            del checkpoint
-            checkpoint = temp_checkpoint
-        return checkpoint
-    except FileNotFoundError:
-        raise logging.critical(FileNotFoundError(f"\n=> No model found at '{filename}'"))
-
-
-def verify_weights(num_classes, weights):
-    """Verifies that the number of weights equals the number of classes if any are given
-    Args:
-        num_classes: number of classes defined in the configuration file
-        weights: weights defined in the configuration file
-    """
-    if num_classes == 1 and len(weights) == 2:
-        logging.warning(
-            "got two class weights for single class defined in configuration file; will assume index 0 = background")
-    elif num_classes != len(weights):
-        raise ValueError(f'The number of class weights {len(weights)} '
-                         f'in the configuration file is different than the number of classes {num_classes}')
-
-
-def set_hyperparameters(params,
-                        model,
-                        checkpoint,
-                        loss_fn,
-                        optimizer,
-                        class_weights=None,
-                        inference: str = ''):
-    """
-    Function to set hyperparameters based on values provided in yaml config file.
-    If none provided, default functions values may be used.
-    :param params: (dict) Parameters found in the yaml config file
-    :param num_classes: (int) number of classes for current task
-    :param model: initialized model
-    :param checkpoint: (dict) state dict as loaded by model_choice.py
-    :param dontcare_val: value in label to ignore during loss calculation
-    :param loss_fn: loss function
-    :param optimizer: optimizer function
-    :param class_weights: class weights for loss function
-    :param inference: (str) path to inference checkpoint (used in load_from_checkpoint())
-    :return: model, criterion, optimizer, lr_scheduler, num_gpus
-    """
-    # set mandatory hyperparameters values with those in config file if they exist
-    lr = get_key_def('lr', params['training'], 0.0001)
-    weight_decay = get_key_def('weight_decay', params['optimizer']['params'], 0)
-    step_size = get_key_def('step_size', params['scheduler']['params'], 4)
-    gamma = get_key_def('gamma', params['scheduler']['params'], 0.9)
-    class_weights = torch.tensor(class_weights) if class_weights else None
-    # Loss function
-    if loss_fn['_target_'] in ['torch.nn.CrossEntropyLoss', 'losses.focal_loss.FocalLoss',
-                               'losses.ohem_loss.OhemCrossEntropy2d']:
-        criterion = instantiate(loss_fn, weight=class_weights)
-    else:
-        criterion = instantiate(loss_fn)
-    # Optimizer
-    opt_fn = optimizer
-    optimizer = create_optimizer(params=model.parameters(), mode=opt_fn, base_lr=lr, weight_decay=weight_decay)
-    lr_scheduler = optim.lr_scheduler.StepLR(optimizer=optimizer, step_size=step_size, gamma=gamma)
-
-    if checkpoint:
-        tqdm.write(f'Loading checkpoint...')
-        model, optimizer = load_from_checkpoint(checkpoint, model, optimizer=optimizer, inference=inference)
-
-    return model, criterion, optimizer, lr_scheduler
-
-
-def net(model_name: str,
-        num_bands: int,
-        num_channels: int,
-        num_devices: int,
-        train_state_dict_path: str = None,
-        pretrained: bool = True,
-        dropout_prob: float = False,
-        loss_fn: str = None,
-        optimizer: str = None,
-        class_weights: Sequence = None,
-        net_params=None,
-        conc_point: str = None,
-        inference_state_dict: str = None):
-    """Define the neural net"""
-    msg = f'\nNumber of bands specified incompatible with this model. Requires 3 band data.'
-    pretrained = False if train_state_dict_path or inference_state_dict else pretrained
     dropout = True if dropout_prob else False
-    model = None
-
     if model_name == 'unetsmall':
         model = unet.UNetSmall(num_channels, num_bands, dropout, dropout_prob)
     elif model_name == 'unet':
@@ -176,7 +79,7 @@ def net(model_name: str,
     elif model_name == 'checkpointed_unet':
         model = checkpointed_unet.UNetSmall(num_channels, num_bands, dropout, dropout_prob)
     elif model_name == 'deeplabv3_pretrained':
-        model = DeepLabV3(encoder_name='resnet101', in_channels=num_bands, classes=num_channels)
+        model = smp.DeepLabV3(encoder_name='resnet101', in_channels=num_bands, classes=num_channels)
     elif model_name == 'deeplabv3_resnet101_dualhead':
         model = DeepLabV3_dualhead(encoder_name='resnet101', in_channels=num_bands, classes=num_channels,
                                    conc_point=conc_point)
@@ -192,45 +95,129 @@ def net(model_name: str,
     else:
         raise logging.critical(ValueError(f'\nThe model name {model_name} in the config.yaml is not defined.'))
 
-    if inference_state_dict:
-        state_dict_path = inference_state_dict
-        checkpoint = load_checkpoint(state_dict_path)
-        return model, checkpoint, model_name
+    return model
 
+
+def read_checkpoint(filename):
+    """
+    Loads checkpoint from provided path to GDL's expected format,
+    ie model's state dictionary should be under "model_state_dict" and
+    optimizer's state dict should be under "optimizer_state_dict" as suggested by pytorch:
+    https://pytorch.org/tutorials/beginner/saving_loading_models.html#save
+    :param filename: path to checkpoint as .pth.tar or .pth
+    :return: (dict) checkpoint ready to be loaded into model instance
+    """
+    if not filename:
+        logging.warning(f"No path to checkpoint provided.")
+        return None
+    try:
+        logging.info(f"\n=> loading model '{filename}'")
+        # For loading external models with different structure in state dict.
+        checkpoint = torch.load(filename, map_location='cpu')
+        if 'model_state_dict' not in checkpoint.keys():
+            val_set = set()
+            for val in checkpoint.values():
+                val_set.add(type(val))
+            if len(val_set) == 1 and list(val_set)[0] == torch.Tensor:
+                # places entire state_dict inside expected key
+                new_checkpoint = OrderedDict()
+                new_checkpoint['model_state_dict'] = OrderedDict({k: v for k, v in checkpoint.items()})
+                del checkpoint
+                checkpoint = new_checkpoint
+            # Covers gdl's checkpoints at version <=2.0.1
+            elif 'model' in checkpoint.keys():
+                checkpoint['model_state_dict'] = checkpoint['model']
+                del checkpoint['model']
+            else:
+                raise ValueError(f"GDL cannot find weight in provided checkpoint")
+        if 'optimizer_state_dict' not in checkpoint.keys():
+            try:
+                # Covers gdl's checkpoints at version <=2.0.1
+                checkpoint['optimizer_state_dict'] = checkpoint['optimizer']
+                del checkpoint['optimizer']
+            except KeyError:
+                logging.critical(f"No optimizer state dictionary was found in provided checkpoint")
+        return checkpoint
+    except FileNotFoundError:
+        raise logging.critical(FileNotFoundError(f"\n=> No model found at '{filename}'"))
+
+
+def adapt_checkpoint_to_dp_model(checkpoint: dict, model: Union[nn.Module, nn.DataParallel]):
+    """
+    Adapts a generic checkpoint to be loaded to a DataParallel model.
+    See: https://github.com/bearpaw/pytorch-classification/issues/27
+    Also: https://discuss.pytorch.org/t/solved-keyerror-unexpected-key-module-encoder-embedding-weight-in-state-dict/1686/3
+
+    Args:
+        checkpoint: a dict containing parameters and
+            persistent buffers under "model_state_dict" key
+        model: a pytorch model to adapt checkpoint to (especially if model is a nn.DataParallel class)
+    """
+    if isinstance(model, nn.DataParallel):
+        new_state_dict = OrderedDict()
+        for k, v in checkpoint['model_state_dict'].items():
+            if 'module' not in k:
+                k = 'module.'+k
+            else:
+                k = k.replace('features.module.', 'module.features.')
+            new_state_dict[k]=v
+        new_state_dict['model_state_dict'] = {'module.' + k: v for k, v in checkpoint['model_state_dict'].items()}
+        del checkpoint
+        checkpoint = {}
+        checkpoint['model_state_dict'] = new_state_dict['model_state_dict']
+    elif isinstance(model, nn.Module):
+        logging.info(f"Provided model is not a DataParallel model. No need to adapt checkpoint to ordinary model")
     else:
-        if train_state_dict_path is not None:
-            checkpoint = load_checkpoint(train_state_dict_path)
-        else:
-            checkpoint = None
-        # list of GPU devices that are available and unused. If no GPUs, returns empty list
-        gpu_devices_dict = get_device_ids(num_devices)
-        num_devices = len(gpu_devices_dict.keys())
-        if num_devices == 1:
-            logging.info(f"\nUsing Cuda device 'cuda:{list(gpu_devices_dict.keys())[0]}'")
-        elif num_devices > 1:
-            logging.info(f"\nUsing data parallel on devices: {list(gpu_devices_dict.keys())[1:]}. "
-                         f"Main device: 'cuda:{list(gpu_devices_dict.keys())[0]}'")
-            try:  # For HPC when device 0 not available. Error: Invalid device id (in torch/cuda/__init__.py).
-                # DataParallel adds prefix 'module.' to state_dict keys
-                model = nn.DataParallel(model, device_ids=list(gpu_devices_dict.keys()))
-            except AssertionError:
-                logging.warning(f"\nUnable to use devices with ids {gpu_devices_dict.keys()}"
-                                f"Trying devices with ids {list(range(len(gpu_devices_dict.keys())))}")
-                model = nn.DataParallel(model, device_ids=list(range(len(gpu_devices_dict.keys()))))
-        else:
-            logging.warning(f"No Cuda device available. This process will only run on CPU\n")
-        logging.info(f'\nSetting model, criterion, optimizer and learning rate scheduler...')
+        return ValueError(f"Cannot adapt checkpoint to model of class '{type(model)}'."
+                          f"\nThis adapter only supports 'nn.Module' and 'nn.DataParallel' models")
+    return checkpoint
 
-        device = set_device(gpu_devices_dict=gpu_devices_dict)
-        model.to(device)
 
-        model, criterion, optimizer, lr_scheduler = set_hyperparameters(params=net_params,
-                                                                        model=model,
-                                                                        checkpoint=checkpoint,
-                                                                        loss_fn=loss_fn,
-                                                                        optimizer=optimizer,
-                                                                        class_weights=class_weights,
-                                                                        inference=inference_state_dict)
-        criterion = criterion.to(device)
+def to_dp_model(model, devices: List):
+    """
+    Converts a model to a DataParallel model given a list of device ids as integers
+    @param model: nn.Module (pytorch model)
+    @param devices: list of devices ids as integers
+    @return:
+    """
+    if not devices or len(devices) == 1:
+        return model
+    logging.info(f"\nUsing data parallel on devices: {devices}. "
+                 f"Main device: 'cuda:{devices[0]}'")
+    try:  # For HPC when device 0 not available. Error: Invalid device id (in torch/cuda/__init__.py).
+        model = nn.DataParallel(model, device_ids=devices)
+    except AssertionError:
+        logging.warning(f"\nUnable to use devices with ids {devices}"
+                        f"Trying devices with ids {list(range(len(devices)))}")
+        model = nn.DataParallel(model, device_ids=list(range(len(devices))))
+    return model
 
-        return model, model_name, criterion, optimizer, lr_scheduler, device, gpu_devices_dict
+
+def define_model(
+        model_name,
+        num_bands,
+        num_classes,
+        dropout_prob,
+        conc_point: str = None,
+        main_device: str = 'cpu',
+        devices: List = [],
+        state_dict_path: str = None,
+        state_dict_strict_load: bool = True,
+):
+    """
+    Defines model's architecture with weights from provided checkpoint and pushes to device(s)
+    @return:
+    """
+    model = define_model_architecture(
+        model_name=model_name,
+        num_bands=num_bands,
+        num_channels=num_classes,
+        dropout_prob=dropout_prob,
+        conc_point=conc_point
+    )
+    model = to_dp_model(model=model, devices=devices[1:]) if len(devices) > 1 else model
+    model.to(main_device)
+    if state_dict_path:
+        checkpoint = read_checkpoint(state_dict_path)
+        model.load_state_dict(state_dict=checkpoint['model_state_dict'], strict=state_dict_strict_load)
+    return model

--- a/tests/loss/test_losses.py
+++ b/tests/loss/test_losses.py
@@ -1,11 +1,10 @@
 from pathlib import Path
 
-import torchvision.models
 from hydra import initialize, compose
 from hydra.core.hydra_config import HydraConfig
 from hydra.utils import to_absolute_path
 
-from models.model_choice import set_hyperparameters
+from utils.loss import define_loss, verify_weights
 
 
 class Test_Losses(object):
@@ -13,6 +12,9 @@ class Test_Losses(object):
     def test_set_hyperparameters(self) -> None:
         with initialize(config_path="../../config", job_name="test_ci"):
             for dataset_type in ['binary', 'multiclass']:
+                num_classes = 1 if dataset_type == 'binary' else 5
+                class_weights = [1/num_classes for i in range(num_classes)]
+                verify_weights(num_classes, class_weights)
                 for loss_config in Path(to_absolute_path(f"../../config/loss/{dataset_type}")).glob('*.yaml'):
                     cfg = compose(config_name="gdl_config_template",
                                   overrides=[f"loss={dataset_type}/{loss_config.stem}"],
@@ -20,11 +22,4 @@ class Test_Losses(object):
                     hconf = HydraConfig()
                     hconf.set_config(cfg)
                     del cfg.loss.is_binary  # prevent exception at instantiation
-                    set_hyperparameters(
-                        params={'training': None, 'optimizer': {'params': None},
-                                    'scheduler': {'params': None}},
-                        model=torchvision.models.resnet18(),
-                        checkpoint=None,
-                        loss_fn=cfg.loss,
-                        optimizer='sgd',
-                    )
+                    define_loss(loss_params=cfg.loss, class_weights=class_weights)

--- a/tests/model/test_models.py
+++ b/tests/model/test_models.py
@@ -1,16 +1,21 @@
 import logging
-from collections import OrderedDict
+import os
 from pathlib import Path
 
 import torch
+import torchvision.models
 from hydra import initialize, compose
 from hydra.core.hydra_config import HydraConfig
 from hydra.utils import to_absolute_path
+from torch import nn
 
-from models.model_choice import net
+from models import unet
+from models.model_choice import read_checkpoint, adapt_checkpoint_to_dp_model, define_model, define_model_architecture
+from utils.optimizer import create_optimizer
+from utils.utils import get_device_ids, set_device
 
 
-class Test_Models(object):
+class Test_Models_Zoo(object):
     """Tests all geo-deep-learning's models instantiation and forward method"""
     def test_net(self) -> None:
         with initialize(config_path="../../config", job_name="test_ci"):
@@ -26,31 +31,81 @@ class Test_Models(object):
                 if cfg.model['model_name'] == 'deeplabv3_resnet101_dualhead':
                     for layer in ['conv1', 'maxpool', 'layer2', 'layer3', 'layer4']:
                         logging.info(layer)
-                        model, model_name, criterion, optimizer, lr_scheduler, device, gpu_devices_dict = net(
+                        model = define_model_architecture(
                             model_name=cfg.model['model_name'],
                             num_bands=4,
                             num_channels=4,
-                            num_devices=0,
-                            net_params={'training': None, 'optimizer': {'params': None},
-                                        'scheduler': {'params': None}},
-                            inference_state_dict=None,
                             conc_point=layer,
-                            loss_fn={'_target_': 'torch.nn.CrossEntropyLoss'},
-                            optimizer='sgd',
                         )
                         output = model(rand_img)
                         print(output.shape)
                 else:
-                    model, model_name, criterion, optimizer, lr_scheduler, device, gpu_devices_dict = net(
+                    model = define_model_architecture(
                         model_name=cfg.model['model_name'],
                         num_bands=4,
                         num_channels=4,
-                        num_devices=0,
-                        net_params={'training': None, 'optimizer': {'params': None},
-                                    'scheduler': {'params': None}},
-                        inference_state_dict=None,
-                        loss_fn={'_target_': 'torch.nn.CrossEntropyLoss'},
-                        optimizer='sgd',
-                        )
+                    )
                     output = model(rand_img)
                     print(output.shape)
+
+
+class test_read_checkpoint():
+    """
+    Tests reading a checkpoint saved outside GDL into memory
+    """
+    dummy_model = torchvision.models.resnet18()
+    dummy_optimizer = create_optimizer(dummy_model.parameters())
+    filename = "test.pth.tar"
+    torch.save(dummy_model.state_dict(), filename)
+    read_checkpoint(filename)
+    # test gdl's checkpoints at version <=2.0.1
+    torch.save({'epoch': 999,
+                'params': {'model': 'resnet18'},
+                'model': dummy_model.state_dict(),
+                'best_loss': 0.1,
+                'optimizer': dummy_optimizer.state_dict()}, filename)
+    read_checkpoint(filename)
+    os.remove(filename)
+
+
+class test_adapt_checkpoint_to_dp_model():
+    """
+    Tests adapting a generic checkpoint to a DataParallel model, then loading it to model
+    """
+    dummy_model = torchvision.models.resnet18()
+    filename = "test.pth.tar"
+    num_devices = 1
+    gpu_devices_dict = get_device_ids(num_devices)
+    torch.save(dummy_model.state_dict(), filename)
+    checkpoint = read_checkpoint(filename)
+    device_ids = list(gpu_devices_dict.keys()) if len(gpu_devices_dict.keys()) >= 1 else None
+    dummy_dp_model = nn.DataParallel(dummy_model, device_ids=device_ids)
+    checkpoint = adapt_checkpoint_to_dp_model(checkpoint, dummy_dp_model)
+    dummy_dp_model.load_state_dict(checkpoint['model_state_dict'])
+    os.remove(filename)
+
+
+class test_define_model_multigpu():
+    """
+    Tests defining model architecture with weights from provided checkpoint and pushing to multiple devices if possible
+    """
+    dummy_model = unet.UNet(4, 4, True, 0.5)
+    filename = "test.pth.tar"
+    torch.save(dummy_model.state_dict(), filename)
+
+    gpu_devices_dict = get_device_ids(4)
+    device = set_device(gpu_devices_dict=gpu_devices_dict)
+    if len(gpu_devices_dict.keys()) == 0:
+        logging.critical(f"No GPUs available. Cannot perform multi-gpu testing.")
+    else:
+        define_model(
+            model_name='unet',
+            num_bands=4,
+            num_classes=4,
+            dropout_prob=0.5,
+            conc_point=None,
+            main_device=device,
+            devices=list(gpu_devices_dict.keys()),
+            state_dict_path=filename,
+            state_dict_strict_load=True,
+        )

--- a/train_segmentation.py
+++ b/train_segmentation.py
@@ -7,7 +7,6 @@ from PIL import Image
 from hydra.utils import to_absolute_path
 from tqdm import tqdm
 from pathlib import Path
-from shutil import copy
 from datetime import datetime
 from typing import Sequence
 from collections import OrderedDict
@@ -18,8 +17,10 @@ from sklearn.utils import compute_sample_weight
 from utils import augmentation as aug, create_dataset
 from utils.logger import InformationLogger, save_logs_to_bucket, tsv_line, dict_path, get_logger, set_tracker
 from utils.metrics import report_classification, create_metrics_dict, iou
-from models.model_choice import net, load_checkpoint, verify_weights
-from utils.utils import load_from_checkpoint, gpu_stats, get_key_def, read_modalities
+from models.model_choice import read_checkpoint, define_model, adapt_checkpoint_to_dp_model
+from utils.loss import verify_weights, define_loss
+from utils.optimizer import create_optimizer
+from utils.utils import gpu_stats, get_key_def, read_modalities, get_device_ids, set_device
 from utils.visualization import vis_from_batch
 # Set the logging file
 logging = get_logger(__name__)  # import logging
@@ -490,15 +491,15 @@ def train(cfg: DictConfig) -> None:
 
     # MODEL PARAMETERS
     class_weights = get_key_def('class_weights', cfg['dataset'], default=None)
-    loss_fn = cfg.loss
-    if loss_fn.is_binary and not num_classes == 1:
+    if cfg.loss.is_binary and not num_classes == 1:
         raise ValueError(f"Parameter mismatch: a binary loss was chosen for a {num_classes}-class task")
-    elif not loss_fn.is_binary and num_classes == 1:
+    elif not cfg.loss.is_binary and num_classes == 1:
         raise ValueError(f"Parameter mismatch: a multiclass loss was chosen for a 1-class (binary) task")
-    del loss_fn.is_binary  # prevent exception at instantiation
+    del cfg.loss.is_binary  # prevent exception at instantiation
     optimizer = get_key_def('optimizer_name', cfg['optimizer'], default='adam', expected_type=str)  # TODO change something to call the function
     pretrained = get_key_def('pretrained', cfg['model'], default=True, expected_type=bool)
-    train_state_dict_path = get_key_def('state_dict_path', cfg['general'], default=None, expected_type=str)
+    train_state_dict_path = get_key_def('state_dict_path', cfg['training'], default=None, expected_type=str)
+    state_dict_strict = get_key_def('state_dict_strict_load', cfg['training'], default=True, expected_type=bool)
     dropout_prob = get_key_def('factor', cfg['scheduler']['params'], default=None, expected_type=float)
     # if error
     if train_state_dict_path and not Path(train_state_dict_path).is_file():
@@ -507,10 +508,12 @@ def train(cfg: DictConfig) -> None:
         )
     if class_weights:
         verify_weights(num_classes, class_weights)
-    # Read the concatenation point
-    # TODO: find a way to maybe implement it in classification one day
-    conc_point = None
-    # conc_point = get_key_def('concatenate_depth', params['global'], None)
+    # Read the concatenation point if requested model is deeplabv3 dualhead  
+    conc_point = get_key_def('conc_point', cfg['model'], None)
+    lr = get_key_def('lr', cfg['training'], default=0.0001, expected_type=float)
+    weight_decay = get_key_def('weight_decay', cfg['optimizer']['cfg'], default=0, expected_type=float)
+    step_size = get_key_def('step_size', cfg['scheduler']['cfg'], default=4, expected_type=int)
+    gamma = get_key_def('gamma', cfg['scheduler']['cfg'], default=0.9, expected_type=float)
 
     # GPU PARAMETERS
     num_devices = get_key_def('num_gpus', cfg['training'], default=0)
@@ -577,24 +580,31 @@ def train(cfg: DictConfig) -> None:
                         f'\nWill be overridden to 255 during visualization only. Problems may occur.')
 
     # overwrite dontcare values in label if loss doens't implement ignore_index
-    dontcare2backgr = False if 'ignore_index' in loss_fn.keys() else True
+    dontcare2backgr = False if 'ignore_index' in cfg.loss.keys() else True
 
     # Will check if batch size needs to be a lower value only if cropping samples during training
     calc_eval_bs = True if crop_size else False
+    
+    # Set device(s)
+    gpu_devices_dict = get_device_ids(num_devices)
+    device = set_device(gpu_devices_dict=gpu_devices_dict)
+
     # INSTANTIATE MODEL AND LOAD CHECKPOINT FROM PATH
-    model, model_name, criterion, optimizer, lr_scheduler, device, gpu_devices_dict = \
-        net(model_name=model_name,
-            num_bands=num_bands,
-            num_channels=num_classes,
-            num_devices=num_devices,
-            train_state_dict_path=train_state_dict_path,
-            pretrained=pretrained,
-            dropout_prob=dropout_prob,
-            loss_fn=loss_fn,
-            class_weights=class_weights,
-            optimizer=optimizer,
-            net_params=cfg,
-            conc_point=conc_point)
+    model = define_model(
+        model_name=model_name,
+        num_bands=num_bands,
+        num_classes=num_classes,
+        dropout_prob=dropout_prob, 
+        conc_point=conc_point,
+        main_device=device,
+        devices=list(gpu_devices_dict.keys()),
+        state_dict_path=train_state_dict_path,
+        state_dict_strict_load=state_dict_strict,
+    )
+    criterion = define_loss(loss_params=cfg.loss, class_weights=class_weights)
+    criterion = criterion.to(device) 
+    optimizer = create_optimizer(model.parameters(), mode=optimizer, base_lr=lr, weight_decay=weight_decay)
+    lr_scheduler = optimizer.lr_scheduler.StepLR(optimizer=optimizer, step_size=step_size, gamma=gamma)
 
     logging.info(f'Instantiated {model_name} model with {num_classes} output channels.\n')
 
@@ -708,9 +718,9 @@ def train(cfg: DictConfig) -> None:
             state_dict = model.module.state_dict() if num_devices > 1 else model.state_dict()
             torch.save({'epoch': epoch,
                         'params': cfg,
-                        'model': state_dict,
+                        'model_state_dict': state_dict,
                         'best_loss': best_loss,
-                        'optimizer': optimizer.state_dict()}, filename)
+                        'optimizer_state_dict': optimizer.state_dict()}, filename)
             if bucket_name:
                 bucket_filename = bucket_output_path.joinpath('checkpoint.pth.tar')
                 bucket.upload_file(filename, bucket_filename)
@@ -739,8 +749,9 @@ def train(cfg: DictConfig) -> None:
 
     # load checkpoint model and evaluate it on test dataset.
     if int(cfg['general']['max_epochs']) > 0:   # if num_epochs is set to 0, model is loaded to evaluate on test set
-        checkpoint = load_checkpoint(filename)
-        model, _ = load_from_checkpoint(checkpoint, model)
+        checkpoint = read_checkpoint(filename)
+        checkpoint = adapt_checkpoint_to_dp_model(checkpoint, model)
+        model.load_state_dict(state_dict=checkpoint)
 
     if tst_dataloader:
         tst_report = evaluation(eval_loader=tst_dataloader,

--- a/train_segmentation.py
+++ b/train_segmentation.py
@@ -3,7 +3,6 @@ import time
 import h5py
 import torch
 import numpy as np
-from PIL import Image
 from hydra.utils import to_absolute_path
 from torch import optim
 from tqdm import tqdm
@@ -43,11 +42,6 @@ def flatten_outputs(predictions, number_of_classes):
     logits_permuted_cont = logits_permuted.contiguous()
     outputs_flatten = logits_permuted_cont.view(-1, number_of_classes)
     return outputs_flatten
-
-
-def loader(path):
-    img = Image.open(path)
-    return img
 
 
 def create_dataloader(samples_folder: Path,
@@ -752,7 +746,7 @@ def train(cfg: DictConfig) -> None:
     if int(cfg['general']['max_epochs']) > 0:   # if num_epochs is set to 0, model is loaded to evaluate on test set
         checkpoint = read_checkpoint(filename)
         checkpoint = adapt_checkpoint_to_dp_model(checkpoint, model)
-        model.load_state_dict(state_dict=checkpoint)
+        model.load_state_dict(state_dict=checkpoint['model_state_dict'])
 
     if tst_dataloader:
         tst_report = evaluation(eval_loader=tst_dataloader,

--- a/train_segmentation.py
+++ b/train_segmentation.py
@@ -5,6 +5,7 @@ import torch
 import numpy as np
 from PIL import Image
 from hydra.utils import to_absolute_path
+from torch import optim
 from tqdm import tqdm
 from pathlib import Path
 from datetime import datetime
@@ -15,7 +16,7 @@ from omegaconf import DictConfig
 from torch.utils.data import DataLoader
 from sklearn.utils import compute_sample_weight
 from utils import augmentation as aug, create_dataset
-from utils.logger import InformationLogger, save_logs_to_bucket, tsv_line, dict_path, get_logger, set_tracker
+from utils.logger import InformationLogger, save_logs_to_bucket, tsv_line, get_logger, set_tracker
 from utils.metrics import report_classification, create_metrics_dict, iou
 from models.model_choice import read_checkpoint, define_model, adapt_checkpoint_to_dp_model
 from utils.loss import verify_weights, define_loss
@@ -604,7 +605,7 @@ def train(cfg: DictConfig) -> None:
     criterion = define_loss(loss_params=cfg.loss, class_weights=class_weights)
     criterion = criterion.to(device) 
     optimizer = create_optimizer(model.parameters(), mode=optimizer, base_lr=lr, weight_decay=weight_decay)
-    lr_scheduler = optimizer.lr_scheduler.StepLR(optimizer=optimizer, step_size=step_size, gamma=gamma)
+    lr_scheduler = optim.lr_scheduler.StepLR(optimizer=optimizer, step_size=step_size, gamma=gamma)
 
     logging.info(f'Instantiated {model_name} model with {num_classes} output channels.\n')
 

--- a/train_segmentation.py
+++ b/train_segmentation.py
@@ -511,9 +511,9 @@ def train(cfg: DictConfig) -> None:
     # Read the concatenation point if requested model is deeplabv3 dualhead  
     conc_point = get_key_def('conc_point', cfg['model'], None)
     lr = get_key_def('lr', cfg['training'], default=0.0001, expected_type=float)
-    weight_decay = get_key_def('weight_decay', cfg['optimizer']['cfg'], default=0, expected_type=float)
-    step_size = get_key_def('step_size', cfg['scheduler']['cfg'], default=4, expected_type=int)
-    gamma = get_key_def('gamma', cfg['scheduler']['cfg'], default=0.9, expected_type=float)
+    weight_decay = get_key_def('weight_decay', cfg['optimizer']['params'], default=0, expected_type=float)
+    step_size = get_key_def('step_size', cfg['scheduler']['params'], default=4, expected_type=int)
+    gamma = get_key_def('gamma', cfg['scheduler']['params'], default=0.9, expected_type=float)
 
     # GPU PARAMETERS
     num_devices = get_key_def('num_gpus', cfg['training'], default=0)

--- a/utils/loss.py
+++ b/utils/loss.py
@@ -1,0 +1,33 @@
+import logging
+
+import torch
+from hydra.utils import instantiate
+
+
+def define_loss(loss_params, class_weights):
+    """
+    Defines a loss criterion from config parameters as expected by hydra's intanstiate utility
+    @return:
+    """
+    class_weights = torch.tensor(class_weights) if class_weights else None
+    # Loss function
+    if loss_params['_target_'] in ['torch.nn.CrossEntropyLoss', 'losses.focal_loss.FocalLoss',
+                               'losses.ohem_loss.OhemCrossEntropy2d']:
+        criterion = instantiate(loss_params, weight=class_weights)
+    else:
+        criterion = instantiate(loss_params)
+    return criterion
+
+
+def verify_weights(num_classes, weights):
+    """Verifies that the length of weights for loss function equals the number of classes if any are given
+    Args:
+        num_classes: number of classes defined in the configuration file
+        weights: weights defined in the configuration file
+    """
+    if num_classes == 1 and len(weights) == 2:
+        logging.warning(
+            "got two class weights for single class defined in configuration file; will assume index 0 = background")
+    elif num_classes != len(weights):
+        raise ValueError(f'The number of class weights {len(weights)} '
+                         f'in the configuration file is different than the number of classes {num_classes}')

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -601,14 +601,13 @@ def print_config(
             'scheduler',
             'augmentation',
             "general.sample_data_dir",
-            "general.state_dict_path",
             "general.save_weights_dir",
         )
     elif config.get('mode') == 'inference':
         fields += (
+            "inference",
             "model",
             "general.sample_data_dir",
-            "general.state_dict_path",
         )
 
     if getpath(config, 'AWS.bucket_name'):

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -40,6 +40,7 @@ try:
 except ModuleNotFoundError:
     logging.warning('The boto3 library counldn\'t be imported. Ignore if not using AWS s3 buckets', ImportWarning)
 
+
 class Interpolate(torch.nn.Module):
     def __init__(self, mode, scale_factor):
         super(Interpolate, self).__init__()
@@ -50,35 +51,6 @@ class Interpolate(torch.nn.Module):
     def forward(self, x):
         x = self.interp(x, scale_factor=self.scale_factor, mode=self.mode, align_corners=False)
         return x
-
-
-def load_from_checkpoint(checkpoint, model, optimizer=None, strict_loading: bool = False, bucket: str = None):
-    """Load weights from a previous checkpoint
-    Args:
-        checkpoint: (dict) checkpoint
-        model: model to replace
-        optimizer: optimiser to be used
-        strict_loading: (bool) If True, loading will be strict (see pytorch doc)
-    """
-    if bucket:
-        checkpoint = bucket.download_file(checkpoint, "saved_model.pth.tar")  # TODO: is this still valid?
-    # Corrects exception with test loop. Problem with loading generic checkpoint into DataParallel model
-    # model.load_state_dict(checkpoint['model'])
-    # https://github.com/bearpaw/pytorch-classification/issues/27
-    # https://discuss.pytorch.org/t/solved-keyerror-unexpected-key-module-encoder-embedding-weight-in-state-dict/1686/3
-    if isinstance(model, nn.DataParallel) and not list(checkpoint['model'].keys())[0].startswith('module'):
-        new_state_dict = model.state_dict().copy()
-        new_state_dict['model'] = {'module.'+k: v for k, v in checkpoint['model'].items()}    # Very flimsy
-        del checkpoint
-        checkpoint = {}
-        checkpoint['model'] = new_state_dict['model']
-
-    model.load_state_dict(checkpoint['model'], strict=strict_loading)
-    log.info(f"\n=> loaded model")
-    if optimizer and 'optimizer' in checkpoint.keys():    # 2nd condition if loading a model without optimizer
-        optimizer.load_state_dict(checkpoint['optimizer'], strict=False)
-
-    return model, optimizer
 
 
 def list_s3_subfolders(bucket, data_path):
@@ -105,9 +77,10 @@ def get_device_ids(
     """
     lst_free_devices = {}
     if not number_requested:
+        logging.warning(f"No GPUs requested. This process will run on CPU")
         return lst_free_devices
     if not torch.cuda.is_available():
-        log.warning(f'\nRequested {number_requested} GPUs, but no CUDA devices found')
+        log.warning(f'\nRequested {number_requested} GPUs, but no CUDA devices found. This process will run on CPU')
         return lst_free_devices
     try:
         nvmlInit()


### PR DESCRIPTION
- adapt train_segmentation.py and inference_segmentation.py to new usage
- move state_dict_path param to default_training.yaml
- implement unit tests for model_choice.py functions
- read_checkpoint(): add robustness (covers external checkpoints with only model weights, and complies to torch's save key naming standard 'model_state_dict' and 'optimizer_state_dict' rather than gdl's 'model' and 'optimizer' keys while being retrocompatible to old gdl models
- create high level define_model() function using all low level models definition/loading functions from model_choice.py
- test_losses.py: implement class weights test
- softcode strict loading boolean for loading provided state_dict at train_segmentation.py

fixes #292 