### PR TITLE
Add automatic mixed precision (amp) for inference

### DIFF
--- a/inference_segmentation.py
+++ b/inference_segmentation.py
@@ -211,7 +211,8 @@ def segmentation(param,
         for transformer in transforms:
             # augment inputs
             augmented_input = transformer.augment_image(inputs)
-            augmented_output = model(augmented_input)
+            with torch.cuda.amp.autocast():
+                augmented_output = model(augmented_input)
             if isinstance(augmented_output, OrderedDict) and 'out' in augmented_output.keys():
                 augmented_output = augmented_output['out']
             logging.debug(f'Shape of augmented output: {augmented_output.shape}')


### PR DESCRIPTION
While we wait for Pytorch Lightning to be implemented, I tested the torch automatic mixed precision AMP on QC10P001, for inference. Times are for raster prediction only.  
Original time for inference : 61m.59s    
Time for inference with AMP : 37m43s   
  
Number of Pixels that are different between both predictions : 20 (out of 403 605 000 pixels total).   
It also reduces the GPU memory needed (slightly).  

Configuration:   
I used Vic's NRG hydro model and tested it on Velum. 