### PR TITLE
Coverage report: ignore error (fixes CI)

### DIFF
--- a/.github/workflows/github-actions-ci.yml
+++ b/.github/workflows/github-actions-ci.yml
@@ -29,4 +29,4 @@ jobs:
           conda activate geo_deep_env
           for z in tests/data/*.zip; do unzip "$z" -d tests/data; done
           coverage run -m pytest --log-cli-level=INFO --capture=tee-sys
-          coverage report -m --sort=Cover
+          coverage report -m --sort=Cover -i


### PR DESCRIPTION
The smallest PR we've seen in a while. Attemps to fix CI on NRCAN's repo. The problem is related to [the coverage tool not finding a file](https://stackoverflow.com/questions/2386975/no-source-for-code-message-in-coverage-py), that at first glance, seems to have no impact if missing. Might as well ignore the problem raised by coverage and causing the CI to fail.