### PR TITLE
AOI handling with VRT

### DIFF
--- a/dataset/aoi.py
+++ b/dataset/aoi.py
@@ -210,10 +210,7 @@ class AOI(object):
         self.raster_open()
         self.raster_meta = self.raster.meta
         self.raster_meta['name'] = self.raster.name
-        if self.raster_src_is_multiband:
-            self.raster_name = Path(self.raster.name)
-        else:
-            self.raster_name = Path(self.raster_raw_input).name.replace("${dataset.bands}", "band")
+        self.raster_name = Path(self.raster_raw_input).parent / Path(self.raster_raw_input).name.replace("${dataset.bands}", "band")
 
         if raster_num_bands_expected:
             validate_num_bands(raster_path=self.raster, num_bands=raster_num_bands_expected)
@@ -261,10 +258,8 @@ class AOI(object):
         # Check aoi_id string
         if aoi_id and not isinstance(aoi_id, str):
             raise TypeError(f'AOI name should be a string. Got {aoi_id} of type {type(aoi_id)}')
-        elif not aoi_id and self.raster_src_is_multiband:
-            aoi_id = Path(self.raster.name).stem  # Defaults to name of image without suffix
-        elif not aoi_id and not self.raster_src_is_multiband:
-            aoi_id = Path(self.raster_raw_input).stem  # Defaults to name of first singleband image without suffix
+        elif not aoi_id:
+            aoi_id = self.raster_name.stem  # Defaults to name of image without suffix
         self.aoi_id = aoi_id
 
         # Check collection string

--- a/dataset/aoi.py
+++ b/dataset/aoi.py
@@ -120,7 +120,7 @@ class AOI(object):
                  attr_field_filter: str = None,
                  attr_values_filter: Sequence = None,
                  download_data: bool = False,
-                 root_dir: str = "dataset",
+                 root_dir: str = "data",
                  for_multiprocessing: bool = False,
                  raster_stats: bool = False,
                  write_multiband: bool = False):
@@ -585,7 +585,7 @@ class AOI(object):
             raise e
 
     @staticmethod
-    def name_raster(root_dir: Union[str, Path], input_path: Union[str, Path], bands_list: Sequence = []):
+    def name_raster(input_path: Union[str, Path], bands_list: Sequence = [], root_dir: Union[str, Path] = "data"):
         """
         Assigns a name to the AOI's raster considering different input types
         @param root_dir:
@@ -594,8 +594,6 @@ class AOI(object):
         @param input_path: path to input raster file as accepted by GDL (see dataset/README.md)
         @param bands_list: list of requested bands from input raster
         """
-        if root_dir is None or not Path(root_dir).is_dir():
-            raise NotADirectoryError(f"Please provide a valid directory as root directory.\nGot {root_dir}")
         raster_name_parent = Path(root_dir)
 
         bands_list_str = [str(band) for band in bands_list]

--- a/dataset/aoi.py
+++ b/dataset/aoi.py
@@ -120,7 +120,7 @@ class AOI(object):
                  attr_field_filter: str = None,
                  attr_values_filter: Sequence = None,
                  download_data: bool = False,
-                 root_dir: str = "data",
+                 root_dir: str = "dataset",
                  for_multiprocessing: bool = False,
                  raster_stats: bool = False,
                  write_multiband: bool = False):

--- a/dataset/aoi.py
+++ b/dataset/aoi.py
@@ -111,7 +111,7 @@ class AOI(object):
     """
 
     def __init__(self, raster: Union[Path, str],
-                 raster_bands_request: List = None,
+                 raster_bands_request: List = [],
                  label: Union[Path, str] = None,
                  split: str = None,
                  aoi_id: str = None,
@@ -209,11 +209,11 @@ class AOI(object):
         self.src_raster_to_dest_multiband(virtual=True)
         self.raster_open()
         self.raster_meta = self.raster.meta
-        self.raster_meta['name'] = self.raster.name
-        if self.raster_src_is_multiband:
-            self.raster_name = Path(self.raster.name)
-        else:
-            self.raster_name = Path(self.raster_raw_input).name.replace("${dataset.bands}", "band")
+        self.raster_name = self.name_raster(
+            input_path=self.raster_raw_input,
+            bands_list=self.raster_bands_request,
+            root_dir=self.root_dir,
+        )
 
         if raster_num_bands_expected:
             validate_num_bands(raster_path=self.raster, num_bands=raster_num_bands_expected)
@@ -261,10 +261,8 @@ class AOI(object):
         # Check aoi_id string
         if aoi_id and not isinstance(aoi_id, str):
             raise TypeError(f'AOI name should be a string. Got {aoi_id} of type {type(aoi_id)}')
-        elif not aoi_id and self.raster_src_is_multiband:
-            aoi_id = Path(self.raster.name).stem  # Defaults to name of image without suffix
-        elif not aoi_id and not self.raster_src_is_multiband:
-            aoi_id = Path(self.raster_raw_input).stem  # Defaults to name of first singleband image without suffix
+        elif not aoi_id:
+            aoi_id = self.raster_name.stem  # Defaults to name of image without suffix
         self.aoi_id = aoi_id
 
         # Check collection string
@@ -480,27 +478,23 @@ class AOI(object):
         out_dir = self.root_dir
 
         if out_dir is None:
-            logging.error(f"There is no path for the output, root_dir shoudn't be None")
+            logging.error(f"There is no path for the output, root_dir shouldn't be None")
             return
         if not self.raster.driver == 'VRT':
             logging.error(f"To write a multi-band raster from single-band files, a VRT must be provided."
                           f"\nGot {self.raster.meta}")
             return
-        if "${dataset.bands}" in self.raster_raw_input:
-            out_tif_path = out_dir / Path(self.raster_raw_input).name.replace("${dataset.bands}", ''.join(self.raster_bands_request))
-        elif is_stac_item(self.raster_raw_input):
-            out_tif_path = out_dir / f"{Path(self.raster_raw_input).stem}_{'-'.join(self.raster_bands_request)}.tif"
-        else:
-            logging.error(f"\nTo write multiband raster from single band imagery, "
-                          f"source imagery must be referenced with expected formats.\n"
-                          f"See dataset/README.md")
-            return
-        logging.debug(f"Writing multi-band raster to {out_tif_path}")
+        logging.debug(f"Writing multi-band raster to {self.raster_name}")
         create_new_raster_from_base(
             input_raster=self.raster,
-            output_raster=str(out_tif_path),
+            output_raster=self.raster_name,
             write_array=self.raster.read())
-        return out_tif_path
+        return self.raster_name
+
+    def close_raster(self) -> None:
+        if self.raster_closed is False:
+            self.raster.close()
+            self.raster_closed = True
 
     @staticmethod
     def parse_input_raster(
@@ -590,15 +584,38 @@ class AOI(object):
                              f'GeoDataFrame: {gdf_tile.info()}')
             raise e
 
-    def close_raster(self) -> None:
-        if self.raster_closed is False:
-            self.raster.close()
-            self.raster_closed = True
+    @staticmethod
+    def name_raster(root_dir: Union[str, Path], input_path: Union[str, Path], bands_list: Sequence = []):
+        """
+        Assigns a name to the AOI's raster considering different input types
+        @param root_dir:
+            Root directory where derived raster would be written.
+            E.g. output from self.write_multiband_from_singleband_rasters_as_vrt()
+        @param input_path: path to input raster file as accepted by GDL (see dataset/README.md)
+        @param bands_list: list of requested bands from input raster
+        """
+        if root_dir is None or not Path(root_dir).is_dir():
+            raise NotADirectoryError(f"Please provide a valid directory as root directory.\nGot {root_dir}")
+        raster_name_parent = Path(root_dir)
+
+        bands_list_str = [str(band) for band in bands_list]
+        if len(bands_list_str) <= 4:
+            bands_suffix = f"bands_{'-'.join(bands_list_str)}"
+        else:  # e.g. hyperspectral imagery
+            bands_suffix = f"{len(bands_list)}bands"
+
+        if "${dataset.bands}" in input_path:  # singleband with ${dataset.bands} pattern (implies band selection)
+            raster_name = raster_name_parent / f"{Path(input_path).stem.replace('${dataset.bands}', bands_suffix)}.tif"
+        elif len(bands_list_str) > 0:  # singleband from stac item or multiband with band selection
+            raster_name = raster_name_parent / f"{Path(input_path).stem}_{bands_suffix}.tif"
+        else:  # multiband, no band selection
+            raster_name = Path(input_path).parent / f"{Path(input_path).stem}.tif"
+        return raster_name
 
 
 def aois_from_csv(
         csv_path: Union[str, Path],
-        bands_requested: List = None,
+        bands_requested: List = [],
         attr_field_filter: str = None,
         attr_values_filter: str = None,
         download_data: bool = False,

--- a/dataset/aoi.py
+++ b/dataset/aoi.py
@@ -213,7 +213,7 @@ class AOI(object):
         if self.raster_src_is_multiband:
             self.raster_name = Path(self.raster.name)
         else:
-            self.raster_name = Path(self.raster_raw_input[0]).name.replace("${dataset.bands}", "")
+            self.raster_name = Path(self.raster_raw_input).name.replace("${dataset.bands}", "band")
 
         if raster_num_bands_expected:
             validate_num_bands(raster_path=self.raster, num_bands=raster_num_bands_expected)

--- a/dataset/aoi.py
+++ b/dataset/aoi.py
@@ -210,7 +210,10 @@ class AOI(object):
         self.raster_open()
         self.raster_meta = self.raster.meta
         self.raster_meta['name'] = self.raster.name
-        self.raster_name = Path(self.raster_raw_input).parent / Path(self.raster_raw_input).name.replace("${dataset.bands}", "band")
+        if self.raster_src_is_multiband:
+            self.raster_name = Path(self.raster.name)
+        else:
+            self.raster_name = Path(self.raster_raw_input).name.replace("${dataset.bands}", "band")
 
         if raster_num_bands_expected:
             validate_num_bands(raster_path=self.raster, num_bands=raster_num_bands_expected)
@@ -258,8 +261,10 @@ class AOI(object):
         # Check aoi_id string
         if aoi_id and not isinstance(aoi_id, str):
             raise TypeError(f'AOI name should be a string. Got {aoi_id} of type {type(aoi_id)}')
-        elif not aoi_id:
-            aoi_id = self.raster_name.stem  # Defaults to name of image without suffix
+        elif not aoi_id and self.raster_src_is_multiband:
+            aoi_id = Path(self.raster.name).stem  # Defaults to name of image without suffix
+        elif not aoi_id and not self.raster_src_is_multiband:
+            aoi_id = Path(self.raster_raw_input).stem  # Defaults to name of first singleband image without suffix
         self.aoi_id = aoi_id
 
         # Check collection string

--- a/dataset/aoi.py
+++ b/dataset/aoi.py
@@ -598,7 +598,7 @@ class AOI(object):
 
         bands_list_str = [str(band) for band in bands_list]
         if len(bands_list_str) <= 4:
-            bands_suffix = f"bands_{'-'.join(bands_list_str)}"
+            bands_suffix = f"{'-'.join(bands_list_str)}"
         else:  # e.g. hyperspectral imagery
             bands_suffix = f"{len(bands_list)}bands"
 

--- a/evaluate_segmentation.py
+++ b/evaluate_segmentation.py
@@ -78,7 +78,7 @@ def main(params):
     """
     start_seg = time.time()
     state_dict = get_key_def('state_dict_path', params['inference'], to_path=True, validate_path_exists=True)
-    bands_requested = get_key_def('bands', params['dataset'], default=None, expected_type=Sequence)
+    bands_requested = get_key_def('bands', params['dataset'], default=[], expected_type=Sequence)
     num_bands = len(bands_requested)
     working_folder = state_dict.parent.joinpath(f'inference_{num_bands}bands')
     raw_data_csv = get_key_def('raw_data_csv', params['inference'], default=working_folder,

--- a/tests/dataset/test_aoi.py
+++ b/tests/dataset/test_aoi.py
@@ -21,9 +21,17 @@ class Test_AOI(object):
         data = read_csv("tests/tiling/tiling_segmentation_binary-multiband_ci.csv")
         row = data[0]
         aoi = AOI(raster=row['tif'], label=row['gpkg'], split=row['split'])
+        assert aoi.raster_raw_input == row['tif']
+        assert aoi.split == row['split']
+        assert str(aoi.label) == row['gpkg']
+        assert aoi.aoi_id == 'SpaceNet_AOI_2_Las_Vegas-056155973080_01_P001-WV03-RGB'
         src_count = rasterio.open(aoi.raster_raw_input).count
         assert src_count == aoi.raster.count
+        assert "tests/data/spacenet/SpaceNet_AOI_2_Las_Vegas-056155973080_01_P001-WV03-RGB.tif" in str(aoi.raster_name)
+        assert isinstance(aoi.label_gdf, gpd.GeoDataFrame) and not aoi.label_gdf.empty
+        assert not aoi.raster_closed
         aoi.close_raster()
+        assert aoi.raster_closed
 
     def test_multiband_input_band_selection(self):
         """Tests reading a multiband raster as input with band selection"""
@@ -63,43 +71,56 @@ class Test_AOI(object):
         """Tests reading a singleband raster as input with ${dataset.bands} pattern"""
         extract_archive(src="tests/data/spacenet.zip")
         data = read_csv("tests/tiling/tiling_segmentation_binary-singleband_ci.csv")
-        for row in data:
-            aoi = AOI(raster=row['tif'], label=row['gpkg'], split=row['split'], raster_bands_request=['R', 'G', 'B'])
-            aoi.close_raster()
+        bands = ['R', 'G', 'B']
+        row = next(iter(data))
+        aoi = AOI(raster=row['tif'], label=row['gpkg'], split=row['split'], raster_bands_request=bands)
+        assert str(aoi.raster_name) == aoi.raster_raw_input.replace("${dataset.bands}", "band")
+        assert aoi.raster_name.stem == aoi.aoi_id
+        assert aoi.raster_bands_request == bands
+        aoi.close_raster()
 
     def test_stac_input(self):
         """Tests singleband raster referenced by stac item as input"""
         extract_archive(src="tests/data/spacenet.zip")
         data = read_csv("tests/tiling/tiling_segmentation_binary-stac_ci.csv")
-        for row in data:
-            aoi = AOI(
-                raster=row['tif'], label=row['gpkg'], split=row['split'],
-                raster_bands_request=['red', 'green', 'blue'])
-            aoi.close_raster()
+        bands = ['red', 'green', 'blue']
+        row = next(iter(data))
+        aoi = AOI(
+            raster=row['tif'], label=row['gpkg'], split=row['split'],
+            raster_bands_request=bands)
+        assert str(aoi.raster_name) == aoi.raster_raw_input
+        assert aoi.raster_name.stem == aoi.aoi_id
+        assert aoi.raster_bands_request == bands
+        for band, actual_raster in zip(["R", "G", "B"], aoi.raster_parsed):
+            root_raster = "http://datacube-stage-data-public.s3.ca-central-1.amazonaws.com/store/imagery/optical/" \
+                          "spacenet-samples/"
+            exp_raster = root_raster + f'SpaceNet_AOI_2_Las_Vegas-056155973080_01_P001-WV03-{band}.tif'
+            assert exp_raster == actual_raster
+        aoi.close_raster()
 
     def test_stac_url_input(self):
         """Tests download of singleband raster as url path referenced by a stac item"""
         extract_archive(src="tests/data/spacenet.zip")
         data = read_csv("tests/tiling/tiling_segmentation_binary-singleband-url_ci.csv")
-        for row in data:
-            aoi = AOI(
-                raster=row['tif'], label=row['gpkg'], split=row['split'],
-               raster_bands_request=['R'], download_data=True, root_dir="data"
-            )
-            assert aoi.download_data is True
-            assert Path("data/SpaceNet_AOI_2_Las_Vegas-056155973080_01_P001-WV03-R.tif").is_file()
-            aoi.close_raster()
-            os.remove("data/SpaceNet_AOI_2_Las_Vegas-056155973080_01_P001-WV03-R.tif")
+        row = next(iter(data))
+        aoi = AOI(
+            raster=row['tif'], label=row['gpkg'], split=row['split'],
+           raster_bands_request=['R'], download_data=True, root_dir="data"
+        )
+        assert aoi.download_data is True
+        assert Path("data/SpaceNet_AOI_2_Las_Vegas-056155973080_01_P001-WV03-R.tif").is_file()
+        aoi.close_raster()
+        os.remove("data/SpaceNet_AOI_2_Las_Vegas-056155973080_01_P001-WV03-R.tif")
 
     def test_missing_label(self):
         """Tests error when provided label file is missing"""
         extract_archive(src="tests/data/spacenet.zip")
         data = read_csv("tests/tiling/tiling_segmentation_binary-multiband_ci.csv")
-        for row in data:
-            row['gpkg'] = "missing_file.gpkg"
-            with pytest.raises(AttributeError):
-                aoi = AOI(raster=row['tif'], label=row['gpkg'], split=row['split'])
-                aoi.close_raster()
+        row = next(iter(data))
+        row['gpkg'] = "missing_file.gpkg"
+        with pytest.raises(AttributeError):
+            aoi = AOI(raster=row['tif'], label=row['gpkg'], split=row['split'])
+            aoi.close_raster()
     
     def test_no_label(self):
         """Test when no label are provided. Should pass for inference. """
@@ -139,64 +160,64 @@ class Test_AOI(object):
         """Tests error when reading a corrupt file"""
         extract_archive(src="tests/data/spacenet.zip")
         data = read_csv("tests/tiling/tiling_segmentation_binary-multiband_ci.csv")
-        for row in data:
-            row['tif'] = "tests/data/massachusetts_buildings_kaggle/corrupt_file.tif"
-            with pytest.raises(BaseException):
-                aoi = AOI(raster=row['tif'], label=None)
-                aoi.close_raster()
+        row = next(iter(data))
+        row['tif'] = "tests/data/massachusetts_buildings_kaggle/corrupt_file.tif"
+        with pytest.raises(BaseException):
+            aoi = AOI(raster=row['tif'], label=None)
+            aoi.close_raster()
 
     def test_image_only(self) -> None:
         """Tests AOI creation with image only, ie no label"""
         extract_archive(src="tests/data/spacenet.zip")
         data = read_csv("tests/tiling/tiling_segmentation_binary-multiband_ci.csv")
-        for row in data:
-            aoi = AOI(raster=row['tif'], label=None)
-            assert aoi.label is None
-            aoi.close_raster()
+        row = next(iter(data))
+        aoi = AOI(raster=row['tif'], label=None)
+        assert aoi.label is None
+        aoi.close_raster()
 
     def test_missing_raster(self) -> None:
         """Tests error when pointing to missing raster"""
         extract_archive(src="tests/data/spacenet.zip")
         data = read_csv("tests/tiling/tiling_segmentation_binary-multiband_ci.csv")
-        for row in data:
-            row['tif'] = "missing_raster.tif"
-            with pytest.raises(RasterioIOError):
-                aoi = AOI(raster=row['tif'], label=row['gpkg'], split=row['split'])
-                aoi.close_raster()
+        row = next(iter(data))
+        row['tif'] = "missing_raster.tif"
+        with pytest.raises(RasterioIOError):
+            aoi = AOI(raster=row['tif'], label=row['gpkg'], split=row['split'])
+            aoi.close_raster()
 
     def test_wrong_split(self) -> None:
         """Tests error when setting a wrong split, ie not 'trn', 'tst' or 'inference'"""
         extract_archive(src="tests/data/spacenet.zip")
         data = read_csv("tests/tiling/tiling_segmentation_binary-multiband_ci.csv")
-        for row in data:
-            row['split'] = "missing_split"
-            with pytest.raises(ValueError):
-                aoi = AOI(raster=row['tif'], label=row['gpkg'], split=row['split'])
-                aoi.close_raster()
+        row = next(iter(data))
+        row['split'] = "missing_split"
+        with pytest.raises(ValueError):
+            aoi = AOI(raster=row['tif'], label=row['gpkg'], split=row['split'])
+            aoi.close_raster()
 
     def test_download_data(self) -> None:
         """Tests download data"""
         extract_archive(src="tests/data/spacenet.zip")
         data = read_csv("tests/tiling/tiling_segmentation_binary-multiband_ci.csv")
-        for row in data:
-            row['tif'] = "http://datacube-stage-data-public.s3.ca-central-1.amazonaws.com/store/imagery/optical/" \
-                         "spacenet-samples/SpaceNet_AOI_2_Las_Vegas-056155973080_01_P001-WV03-N.tif"
-            aoi = AOI(raster=row['tif'], label=row['gpkg'], split=row['split'], download_data=True, root_dir="data")
-            assert Path("data/SpaceNet_AOI_2_Las_Vegas-056155973080_01_P001-WV03-N.tif").is_file()
-            assert aoi.download_data is True
-            aoi.close_raster()
-            os.remove("data/SpaceNet_AOI_2_Las_Vegas-056155973080_01_P001-WV03-N.tif")
+        row = next(iter(data))
+        row['tif'] = "http://datacube-stage-data-public.s3.ca-central-1.amazonaws.com/store/imagery/optical/" \
+                     "spacenet-samples/SpaceNet_AOI_2_Las_Vegas-056155973080_01_P001-WV03-N.tif"
+        aoi = AOI(raster=row['tif'], label=row['gpkg'], split=row['split'], download_data=True, root_dir="data")
+        assert Path("data/SpaceNet_AOI_2_Las_Vegas-056155973080_01_P001-WV03-N.tif").is_file()
+        assert aoi.download_data is True
+        aoi.close_raster()
+        os.remove("data/SpaceNet_AOI_2_Las_Vegas-056155973080_01_P001-WV03-N.tif")
 
     def test_stac_input_missing_band(self):
         """Tests error when requestinga non-existing singleband input rasters from stac item"""
         extract_archive(src="tests/data/spacenet.zip")
         data = read_csv("tests/tiling/tiling_segmentation_binary-stac_ci.csv")
-        for row in data:
-            with pytest.raises(ValueError):
-                aoi = AOI(
-                    raster=row['tif'], label=row['gpkg'], split=row['split'],
-                    raster_bands_request=['ru', 'gris', 'but'])
-                aoi.close_raster()
+        row = next(iter(data))
+        with pytest.raises(ValueError):
+            aoi = AOI(
+                raster=row['tif'], label=row['gpkg'], split=row['split'],
+                raster_bands_request=['ru', 'gris', 'but'])
+            aoi.close_raster()
 
     def test_stac_input_empty_band_request(self):
         """Tests error when band selection is required (stac item) but missing"""
@@ -214,11 +235,11 @@ class Test_AOI(object):
         """Tests error testing no intersection between raster and label"""
         extract_archive(src="tests/data/spacenet.zip")
         data = read_csv("tests/tiling/tiling_segmentation_binary-multiband_ci.csv")
-        for row in data:
-            row['gpkg'] = "tests/data/new_brunswick_aerial/BakerLake_2017_clipped.gpkg"
-            aoi = AOI(raster=row['tif'], label=row['gpkg'], split=row['split'])
-            assert aoi.bounds_iou == 0
-            aoi.close_raster()
+        row = next(iter(data))
+        row['gpkg'] = "tests/data/new_brunswick_aerial/BakerLake_2017_clipped.gpkg"
+        aoi = AOI(raster=row['tif'], label=row['gpkg'], split=row['split'])
+        assert aoi.bounds_iou == 0
+        aoi.close_raster()
 
 
     def test_write_multiband_from_single_band(self) -> None:
@@ -236,23 +257,23 @@ class Test_AOI(object):
         """Tests the 'write_multiband' method with singleband raster as URL"""
         extract_archive(src="tests/data/spacenet.zip")
         data = read_csv("tests/tiling/tiling_segmentation_binary-singleband-url_ci.csv")
-        for row in data:
-            aoi = AOI(raster=row['tif'], label=row['gpkg'], split=row['split'], raster_bands_request=['R', 'G', 'B'],
-                      write_multiband=True, root_dir="data", download_data=True)
-            assert Path("data/SpaceNet_AOI_2_Las_Vegas-056155973080_01_P001-WV03-RGB.tif").is_file()
-            assert aoi.download_data == True
-            aoi.close_raster()
-            for bands in ["RGB", "R", "G", "B"]:
-                os.remove(f"data/SpaceNet_AOI_2_Las_Vegas-056155973080_01_P001-WV03-{bands}.tif")
+        row = next(iter(data))
+        aoi = AOI(raster=row['tif'], label=row['gpkg'], split=row['split'], raster_bands_request=['R', 'G', 'B'],
+                  write_multiband=True, root_dir="data", download_data=True)
+        assert Path("data/SpaceNet_AOI_2_Las_Vegas-056155973080_01_P001-WV03-RGB.tif").is_file()
+        assert aoi.download_data == True
+        aoi.close_raster()
+        for bands in ["RGB", "R", "G", "B"]:
+            os.remove(f"data/SpaceNet_AOI_2_Las_Vegas-056155973080_01_P001-WV03-{bands}.tif")
 
     def test_download_true_not_url(self) -> None:
         """Tests AOI creation if download_data set to True, but not necessary (local image)"""
         extract_archive(src="tests/data/spacenet.zip")
         data = read_csv("tests/tiling/tiling_segmentation_binary-singleband_ci.csv")
-        for row in data:
-            aoi = AOI(raster=row['tif'], label=row['gpkg'], split=row['split'], download_data=True,
-                      raster_bands_request=['R', 'G', 'B'])
-            aoi.close_raster()
+        row = next(iter(data))
+        aoi = AOI(raster=row['tif'], label=row['gpkg'], split=row['split'], download_data=True,
+                  raster_bands_request=['R', 'G', 'B'])
+        aoi.close_raster()
 
     def test_raster_stats_from_stac(self) -> None:
         """Tests the calculation of statistics of raster data as stac item from an AOI instance"""
@@ -268,14 +289,13 @@ class Test_AOI(object):
                                     'std': 13.91999326196311}},
             'all': {'statistics': {'minimum': 0.0, 'maximum': 255.0, 'mean': 16.98176567459573,
                                    'median': 17.666666666666668, 'std': 12.566239874581086}}}
-        for row in data:
-            aoi = AOI(raster=row['tif'], label=row['gpkg'], split=row['split'], raster_bands_request=bands_request)
-            stats = aoi.calc_raster_stats()
-            for band, band_stat in stats.items():
-                assert band_stat['statistics'] == expected_stats[band]['statistics']
-                assert len(band_stat['histogram']['buckets']) == 256
-            aoi.close_raster()
-            break
+        row = next(iter(data))
+        aoi = AOI(raster=row['tif'], label=row['gpkg'], split=row['split'], raster_bands_request=bands_request)
+        stats = aoi.calc_raster_stats()
+        for band, band_stat in stats.items():
+            assert band_stat['statistics'] == expected_stats[band]['statistics']
+            assert len(band_stat['histogram']['buckets']) == 256
+        aoi.close_raster()
 
     def test_raster_stats_not_stac(self) -> None:
         """Tests the calculation of statistics of local multiband raster data from an AOI instance"""
@@ -290,34 +310,34 @@ class Test_AOI(object):
                                       'std': 41.85516710316288}},
             'all': {'statistics': {'minimum': 16.333333333333332, 'maximum': 254.33333333333334,
                                    'mean': 142.8522378159475, 'median': 145.33333333333334, 'std': 45.68388743111347}}}
-        for row in data:
-            aoi = AOI(raster=row['tif'], label=row['gpkg'], split=row['split'])
-            stats = aoi.calc_raster_stats()
-            for band, band_stat in stats.items():
-                assert band_stat['statistics'] == expected_stats[band]['statistics']
-                assert len(band_stat['histogram']['buckets']) == 256
-            aoi.close_raster()
-            break
+        row = next(iter(data))
+        aoi = AOI(raster=row['tif'], label=row['gpkg'], split=row['split'])
+        stats = aoi.calc_raster_stats()
+        for band, band_stat in stats.items():
+            assert band_stat['statistics'] == expected_stats[band]['statistics']
+            assert len(band_stat['histogram']['buckets']) == 256
+        aoi.close_raster()
 
     def test_to_dict(self):
         """Test the 'to_dict()' method on an AOI instance"""
         extract_archive(src="tests/data/spacenet.zip")
         data = read_csv("tests/tiling/tiling_segmentation_binary-stac_ci.csv")
-        for row in data:
-            aoi = AOI(raster=row['tif'], label=row['gpkg'], split=row['split'], raster_bands_request=['red', 'green', 'blue'])
-            aoi.to_dict()
-            aoi.close_raster()
+        bands = ['red', 'green', 'blue']
+        row = next(iter(data))
+        aoi = AOI(raster=row['tif'], label=row['gpkg'], split=row['split'], raster_bands_request=bands)
+        aoi.to_dict()
+        aoi.close_raster()
 
     def test_for_multiprocessing(self) -> None:
         """Tests multiprocessing on AOI instances"""
         extract_archive(src="tests/data/spacenet.zip")
         data = read_csv("tests/tiling/tiling_segmentation_multiclass_ci.csv")
         inputs = []
-        for row in data:
-            aoi = AOI(raster=row['tif'], label=row['gpkg'], split=row['split'], for_multiprocessing=True)
-            inputs.append([aoi_read_raster, aoi])
-            assert aoi.raster_closed is True
-            assert aoi.raster is None
+        row = next(iter(data))
+        aoi = AOI(raster=row['tif'], label=row['gpkg'], split=row['split'], for_multiprocessing=True)
+        inputs.append([aoi_read_raster, aoi])
+        assert aoi.raster_closed is True
+        assert aoi.raster is None
 
         with multiprocessing.get_context('spawn').Pool(None) as pool:
             aoi_meta = pool.map_async(map_wrapper, inputs).get()

--- a/tests/dataset/test_aoi.py
+++ b/tests/dataset/test_aoi.py
@@ -247,9 +247,9 @@ class Test_AOI(object):
         row = data[0]
         aoi = AOI(raster=row['tif'], label=row['gpkg'], split=row['split'], raster_bands_request=['R', 'G', 'B'],
                   write_multiband=True, root_dir="data")
-        assert Path("data/SpaceNet_AOI_2_Las_Vegas-056155973080_01_P001-WV03-bands_R-G-B.tif").is_file()
+        assert Path("data/SpaceNet_AOI_2_Las_Vegas-056155973080_01_P001-WV03-R-G-B.tif").is_file()
         aoi.close_raster()
-        os.remove("data/SpaceNet_AOI_2_Las_Vegas-056155973080_01_P001-WV03-bands_R-G-B.tif")
+        os.remove("data/SpaceNet_AOI_2_Las_Vegas-056155973080_01_P001-WV03-R-G-B.tif")
 
     def test_write_multiband_from_single_band_url(self) -> None:
         """Tests the 'write_multiband' method with singleband raster as URL"""
@@ -258,10 +258,10 @@ class Test_AOI(object):
         row = next(iter(data))
         aoi = AOI(raster=row['tif'], label=row['gpkg'], split=row['split'], raster_bands_request=['R', 'G', 'B'],
                   write_multiband=True, root_dir="data", download_data=True)
-        assert Path("data/SpaceNet_AOI_2_Las_Vegas-056155973080_01_P001-WV03-bands_R-G-B.tif").is_file()
+        assert Path("data/SpaceNet_AOI_2_Las_Vegas-056155973080_01_P001-WV03-R-G-B.tif").is_file()
         assert aoi.download_data is True
         aoi.close_raster()
-        for bands in ["bands_R-G-B", "R", "G", "B"]:
+        for bands in ["R-G-B", "R", "G", "B"]:
             os.remove(f"data/SpaceNet_AOI_2_Las_Vegas-056155973080_01_P001-WV03-{bands}.tif")
 
     def test_download_true_not_url(self) -> None:
@@ -354,10 +354,10 @@ class Test_AOI(object):
             ("tests/data/spacenet/SpaceNet_AOI_2_Las_Vegas-056155973080_01_P001-WV03-RGB.tif", []),
         ]
         expected_list = [
-            "tests/data/spacenet/SpaceNet_AOI_2_Las_Vegas-056155973080_01_P001-WV03-bands_R-G-B.tif",
-            "tests/data/spacenet/SpaceNet_AOI_2_Las_Vegas-056155973080_01_P001-WV03-bands_R-G-B.tif",
-            "tests/data/spacenet/SpaceNet_AOI_2_Las_Vegas-056155973080_01_P001-WV03_bands_red-green-blue.tif",
-            "tests/data/spacenet/SpaceNet_AOI_2_Las_Vegas-056155973080_01_P001-WV03-RGB_bands_1-2-3.tif",
+            "tests/data/spacenet/SpaceNet_AOI_2_Las_Vegas-056155973080_01_P001-WV03-R-G-B.tif",
+            "tests/data/spacenet/SpaceNet_AOI_2_Las_Vegas-056155973080_01_P001-WV03-R-G-B.tif",
+            "tests/data/spacenet/SpaceNet_AOI_2_Las_Vegas-056155973080_01_P001-WV03_red-green-blue.tif",
+            "tests/data/spacenet/SpaceNet_AOI_2_Las_Vegas-056155973080_01_P001-WV03-RGB_1-2-3.tif",
             "tests/data/spacenet/SpaceNet_AOI_2_Las_Vegas-056155973080_01_P001-WV03-RGB_7bands.tif",
             "tests/data/spacenet/SpaceNet_AOI_2_Las_Vegas-056155973080_01_P001-WV03-RGB.tif",
         ]

--- a/tiling_segmentation.py
+++ b/tiling_segmentation.py
@@ -437,7 +437,7 @@ def main(cfg: DictConfig) -> None:
     )
     for aoi in tqdm(list_data_prep, position=0, leave=False):
         try:
-            logging.info(f"\nReading as array: {aoi.raster.name}")
+            logging.info(f"\nReading as array: {aoi.raster_name}")
             with _check_rasterio_im_load(aoi.raster) as raster:
                 # 1. Read the input raster image
                 np_input_image, raster, dataset_nodata = image_reader_as_array(input_image=raster)
@@ -497,7 +497,7 @@ def main(cfg: DictConfig) -> None:
             # logging.info(f'\nNumber of samples={number_samples}')
             out_file.flush()
         except OSError:
-            logging.exception(f'\nAn error occurred while preparing samples with "{Path(aoi.raster.name).stem}" (tiff) and '
+            logging.exception(f'\nAn error occurred while preparing samples with "{Path(aoi.raster_name).stem}" (tiff) and '
                               f'{Path(aoi.label).stem} (gpkg).')
             continue
 

--- a/tiling_segmentation.py
+++ b/tiling_segmentation.py
@@ -330,7 +330,7 @@ def main(cfg: DictConfig) -> None:
     """
     # PARAMETERS
     num_classes = len(cfg.dataset.classes_dict.keys())
-    bands_requested = get_key_def('bands', cfg['dataset'], default=None, expected_type=Sequence)
+    bands_requested = get_key_def('bands', cfg['dataset'], default=[], expected_type=Sequence)
     if not bands_requested:
         raise ValueError(f"")
     num_bands = len(bands_requested)

--- a/verify_segmentation.py
+++ b/verify_segmentation.py
@@ -92,7 +92,7 @@ def main(cfg: DictConfig) -> None:
     """
     # PARAMETERS
     num_classes = len(cfg.dataset.classes_dict.keys())
-    bands_requested = get_key_def('bands', cfg['dataset'], default=None, expected_type=Sequence)
+    bands_requested = get_key_def('bands', cfg['dataset'], default=[], expected_type=Sequence)
     csv_file = get_key_def('raw_data_csv', cfg['dataset'], to_path=True, validate_path_exists=True)
     data_dir = get_key_def('raw_data_dir', cfg['dataset'], default="data", to_path=True, validate_path_exists=True)
     download_data = get_key_def('download_data', cfg['dataset'], default=False, expected_type=bool)


### PR DESCRIPTION
fixes #362 

A new method in the AOI class defines a "raster_name" attribute, used mainly for printing during execution, but also as output name of multiband raster if ["write_multiband == True"](https://github.com/NRCan/geo-deep-learning/blob/develop/dataset/aoi.py#L154). 

For the "raster_name" attribute, I decided to suffix the name with bands requested as suggested by @ms888ekb 

For example:
input:"tests/data/spacenet/SpaceNet_AOI_2_Las_Vegas-056155973080_01_P001-WV03-${dataset.bands}.tif" 
bands requested: ["R", "G", "B"]
"raster_name" output: "tests/data/spacenet/SpaceNet_AOI_2_Las_Vegas-056155973080_01_P001-WV03-RGB_**R-G-B**.tif"

You'll also notice that when more than 4 bands are requested, the suffix "raster_name" will become the actual number of bands, not the names of bands juxtaposed as a string. For example:
input:"tests/data/spacenet/SpaceNet_AOI_2_Las_Vegas-056155973080_01_P001-WV03-RGB.tif" 
bands requested: [1, 2, 3, 4, 5, 6, 7]
"raster_name" output: "tests/data/spacenet/SpaceNet_AOI_2_Las_Vegas-056155973080_01_P001-WV03-RGB_**7bands**.tif"

See more examples here: https://github.com/NRCan/geo-deep-learning/pull/364/files#r1000666932

@valhassan is that all right with you?