### PR TITLE
included citation file for github

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,15 @@
+# This CITATION.cff file was generated with cffinit.
+# Visit https://bit.ly/cffinit to generate yours today!
+
+cff-version: 1.2.0
+title: Geo-deep-learning
+message: >-
+  If you use this software, please cite it using the
+  metadata from this file.
+type: software
+authors:
+  - affiliation: 'Natural Resources Canada, Government of Canada'
+repository-code: 'https://github.com/NRCan/geo-deep-learning'
+license: MIT
+version: 1.2.0
+date-released: '2020-10-13'


### PR DESCRIPTION
I've created a citation file that can be used in github to automatically populate a reference option on the left side bar of the main repo page. 
I used information from github [resource](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files), information from issues #230, and used [this tool](https://citation-file-format.github.io/cff-initializer-javascript/#/)