### PR TITLE
Quick: fix max GPU RAM finder and remove an hydra error msg

### DIFF
--- a/GDL.py
+++ b/GDL.py
@@ -12,7 +12,7 @@ config_path = "config"
 config_name = "gdl_config_template"
 
 
-@hydra.main(config_path=config_path, config_name=config_name)
+@hydra.main(version_base=None, config_path=config_path, config_name=config_name)
 def run_gdl(cfg: DictConfig) -> None:
     """
     Function general for Geo Deep-Learning using Hydra library to rules all the

--- a/inference_segmentation.py
+++ b/inference_segmentation.py
@@ -118,6 +118,7 @@ def auto_batch_size_finder(datamodule, device, model, single_class_mode=False, m
             logging.info(f"Reached maximum batch size for image size. "
                          f"Batch size tuned to {batch_size_trial-bs_step}.")
             datamodule.batch_size = batch_size_trial-bs_step
+            break
 
         eval_gen2tune = eval_batch_generator(
             model=model,
@@ -133,6 +134,7 @@ def auto_batch_size_finder(datamodule, device, model, single_class_mode=False, m
         free, total = torch.cuda.mem_get_info(device)
         if (total-free)/total > max_used_ram/100:
             logging.info(f"Reached GPU RAM threshold of {int(max_used_ram)}%. Batch size tuned to {batch_size_trial}.")
+            break
 
 
 def create_spline_window(window_size: int, power=1):


### PR DESCRIPTION
After the merge of the acceleration of the inference I forgot to had a `break` in the for loop when looking to the max GPU RAM. 
This PR will fix it. 

Adding to that, a error message was appearing for hydra when not specifying the version use for the code, so I add `None` to stop that message. When we put `None` it will use the last version installed in our case at the moment it's 1.2.