### PR TITLE
aoi.py: in to_dict(), format raster's metadata & use coma delimiter in verify report as csv

### DIFF
--- a/dataset/aoi.py
+++ b/dataset/aoi.py
@@ -448,7 +448,7 @@ class AOI(object):
             'id': self.aoi_id,
             'raster_parsed': self.raster_parsed,
             'raster_area': raster_area,
-            'raster_meta': self.raster_meta,
+            'raster_meta': repr(self.raster_meta).replace("\n", "").replace(" ", " ").replace(",", ";"),
             'label_features_nb': len(self.label_gdf),
             'label_features_filtered_nb': len(self.label_gdf_filtered),
             'raster_label_bounds_iou': self.bounds_iou,

--- a/verify_segmentation.py
+++ b/verify_segmentation.py
@@ -163,7 +163,7 @@ def main(cfg: DictConfig) -> None:
 
     logging.info(f"\nWriting to csv: {outpath_csv}...")
     with open(outpath_csv, 'w', newline='') as output_file:
-        dict_writer = csv.DictWriter(output_file, report_list[0].keys(), delimiter=';')
+        dict_writer = csv.DictWriter(output_file, report_list[0].keys())
         dict_writer.writeheader()
         dict_writer.writerows(report_list)
 


### PR DESCRIPTION
fixes #422
fixes #423

The fix was aimed at the same line of code, thus creating a single PR for these two issues.