### PR TITLE
Fix equalization during tiling

### DIFF
--- a/dataset/aoi.py
+++ b/dataset/aoi.py
@@ -703,6 +703,8 @@ def aois_from_csv(
                     download_data=download_data,
                     root_dir=data_dir,
                     for_multiprocessing=for_multiprocessing,
+                    write_dest_raster=write_dest_raster,
+                    equalize_clahe_clip_limit=equalize_clahe_clip_limit,
                 )
                 logging.debug(new_aoi)
                 aois.append(new_aoi)

--- a/dataset/aoi.py
+++ b/dataset/aoi.py
@@ -261,8 +261,8 @@ class AOI(object):
         self.enhance_clip_limit = equalize_clahe_clip_limit
 
         if self.enhance_clip_limit > 0:
-            self.raster_multiband = self.equalize_hist_raster(clip_limit=self.enhance_clip_limit)
-            self.raster = rasterio.open(self.raster_multiband)
+            self.raster_dest = self.equalize_hist_raster(clip_limit=self.enhance_clip_limit)
+            self.raster = rasterio.open(self.raster_dest)
 
         # Check label data
         if label:
@@ -710,6 +710,6 @@ def aois_from_csv(
                 aois.append(new_aoi)
             except FileNotFoundError as e:
                 logging.error(f"{e}\nGround truth file may not exist or is empty.\n"
-                                f"Failed to create AOI:\n{aoi_dict}\n"
-                                f"Index: {i}")
+                              f"Failed to create AOI:\n{aoi_dict}\n"
+                              f"Index: {i}")
     return aois

--- a/tests/test_tiling_segmentation.py
+++ b/tests/test_tiling_segmentation.py
@@ -2,6 +2,7 @@ import itertools
 import shutil
 from pathlib import Path
 
+import numpy
 import pytest
 import rasterio
 from omegaconf import DictConfig
@@ -216,3 +217,37 @@ class TestTiling(object):
         gt = "tests/data/spacenet/SN7_global_monthly_2020_01_mosaic_L15-0331E-1257N_1327_3160_13_uint8_clipped_4326.gpkg"
         with pytest.raises(rasterio.errors.CRSError):
             perc = annot_percent(img, gt)
+
+    def test_tiling_equalization(self):
+        """Tests the tiling process with clahe equalization"""
+        means_per_limit = []
+        for clip_limit in [0, 10, 25]:
+            data_dir = f"data/patches"
+            proj = f"tiling_output_test"
+            Path(data_dir).mkdir(exist_ok=True, parents=True)
+            extract_archive(src="tests/data/massachusetts_buildings_kaggle.zip")
+            cfg = {
+                "general": {"project_name": proj},
+                "debug": True,
+                "dataset": {
+                    "bands": [1, 2, 3],
+                    "raw_data_dir": data_dir,
+                    "raw_data_csv": f"tests/tiling/tiling_segmentation_binary_ci.csv",
+                },
+                "tiling": {
+                    "patch_size": 32,
+                    "train_val_percent": {'val': 0.3},
+                    "clahe_clip_limit": clip_limit,
+                },
+            }
+            cfg = DictConfig(cfg)
+            tiling(cfg)
+            out_labels = (Path(data_dir)/proj).glob("**/images/*.tif")
+            patch_means = []
+            for patch in out_labels:
+                patch_np = rasterio.open(patch).read()
+                patch_means.append(patch_np)
+            aoi_means = int(numpy.asarray(patch_means).mean())
+            means_per_limit.append(aoi_means)
+        assert means_per_limit[0] < means_per_limit[1] < means_per_limit[2]
+        shutil.rmtree(Path(data_dir) / proj)


### PR DESCRIPTION
PR #421 has introduced a bug, where equalization parameters are no longer passed in aois_from_csv(). 
Also, the variable name returned from equalizate_hist_raster in AOI's \_\_init__ hadn't been updated with last refactoring (self.raster_multiband --> self.raster_dest)

Hopefully this kind of bug won't go unnoticed too often as, in this case, it caused the equalization to be skipped (aois_from_csv() not passing down params) or equalized rasters to be ignored during tiling (with tiling.multiprocessing=True, the tiling read the self.raster_dest when the equalized raster was, in fact, under self.raster_multiband...).