### PR TITLE
New Feature - function fetching tag information to raster

### DIFF
--- a/inference_segmentation.py
+++ b/inference_segmentation.py
@@ -423,6 +423,9 @@ def main(params: Union[DictConfig, dict]) -> None:
         logging.info(f'\nSuccessfully inferred on {aoi.raster_name}\nWriting to file: {inference_image}')
         with rasterio.open(inference_image, 'w+', **inf_meta) as dest:
             dest.write(pred)
+            # NOTE: the tags option will be join to the `create_new_raster_from_base` function for later version
+            # add tag to transmit more informations, the checkpoint path in that case
+            dest.update_tags(checkpoint=state_dict)  
         del pred
         try:
             temp_file.unlink()

--- a/tests/utils/test_geoutils.py
+++ b/tests/utils/test_geoutils.py
@@ -10,7 +10,7 @@ from _pytest.fixtures import SubRequest
 from torchgeo.datasets.utils import extract_archive
 
 from dataset.aoi import AOI
-from utils.geoutils import create_new_raster_from_base, bounds_gdf, bounds_riodataset, overlap_poly1_rto_poly2
+from utils.geoutils import create_new_raster_from_base, bounds_gdf, bounds_riodataset, overlap_poly1_rto_poly2, fetch_tag_raster
 from utils.utils import read_csv
 
 
@@ -85,3 +85,11 @@ class TestGeoutils(object):
         label_bounds_box = bounds_gdf(label_gdf)
         raster_bounds_box = bounds_riodataset(raster)
         assert overlap_poly1_rto_poly2(label_bounds_box, raster_bounds_box) == 0.0
+        
+    def test_fetch_tag_raster(self):
+        """Test to verify if the function really fetch the right information from the raster"""
+        raster_file = "tests/data/massachusetts_buildings_kaggle/22978945_15_uint8_clipped.tif"
+        with rasterio.open(raster_file) as dest:
+            dest.update_tags(checkpoint='test/path/to/checkpoint.pth')
+        assert fetch_tag_raster(raster_file, 'checkpoint') == 'test/path/to/checkpoint.pth'
+         

--- a/tests/utils/test_geoutils.py
+++ b/tests/utils/test_geoutils.py
@@ -89,7 +89,10 @@ class TestGeoutils(object):
     def test_fetch_tag_raster(self):
         """Test to verify if the function really fetch the right information from the raster"""
         raster_file = "tests/data/massachusetts_buildings_kaggle/22978945_15_uint8_clipped.tif"
-        with rasterio.open(raster_file) as dest:
-            dest.update_tags(checkpoint='test/path/to/checkpoint.pth')
-        assert fetch_tag_raster(raster_file, 'checkpoint') == 'test/path/to/checkpoint.pth'
+        tag_raster = 'tests/data/massachusetts_buildings_kaggle/tag_raster.tif'
+        with rasterio.open(raster_file, 'r') as src_ds:
+            with rasterio.open(tag_raster, 'w', **src_ds.meta) as dst_ds:
+                dst_ds.update_tags(checkpoint='test/path/to/checkpoint.pth')
+                dst_ds.write(src_ds.read())
+        assert fetch_tag_raster(tag_raster, 'checkpoint') == 'test/path/to/checkpoint.pth'
          

--- a/utils/geoutils.py
+++ b/utils/geoutils.py
@@ -227,16 +227,16 @@ def overlap_poly1_rto_poly2(polygon1: Polygon, polygon2: Polygon) -> float:
     return intersection / (polygon2.area + 1e-30)
 
 
-def multi2poly(returned_vector_pred, layer_name):
+def multi2poly(returned_vector_pred, layer_name=None):
     """
     Convert shapely multipolygon to polygon. If fail return a logging error.
     This function will read an PATH string create an geodataframe and explode
     all multipolygon to polygon and save the geodataframe at the same PATH.
     Args:
         returned_vector_pred: string, geopackage PATH where the post-processing
-                              results are saved
+                              results are saved.
         layer_name: string, the name of layer to look into for multipolygon, the name
-                    represente the classes post-processed
+                    represente the classes post-processed. Default None.
     Return:
         none
     """
@@ -247,5 +247,5 @@ def multi2poly(returned_vector_pred, layer_name):
             gdf_exploded = df.explode(index_parts=True, ignore_index=True)
             gdf_exploded.to_file(returned_vector_pred, layer=layer_name) # overwrite the layer readed
     except Exception as e:
-        logging.error(f"\nSomething went wrong during the convertion of Polygon. \nError {type(e)}: {e}")
+        logging.error(f"\nSomething went wrong during the conversion of Polygon. \nError {type(e)}: {e}")
         

--- a/utils/geoutils.py
+++ b/utils/geoutils.py
@@ -256,7 +256,6 @@ def multi2poly(returned_vector_pred, layer_name=None):
         logging.error(f"\nSomething went wrong during the conversion of Polygon. \nError {type(e)}: {e}")
         
         
-        
 def fetch_tag_raster(raster_path, tag_wanted):
     """
     Fetch the tag(s) information saved inside the tiff.
@@ -269,13 +268,12 @@ def fetch_tag_raster(raster_path, tag_wanted):
     """
     with rasterio.open(raster_path) as tiff_src:
         tags = tiff_src.tags()
-    # check if the tiff have a checkpoint save in 
+    # check if the tiff have the wanted tag save in 
     if tag_wanted in tags.keys():
         return tags[tag_wanted]
     else:
         raise logging.error(
-            f"\nThe tag {tag_wanted} was not found in the {list(tags.keys())},"
+            f"\nThe tag {tag_wanted} was not found in the {tags.keys()},"
             f" try again with one inside that list."
         )
     
- 

--- a/utils/geoutils.py
+++ b/utils/geoutils.py
@@ -23,12 +23,13 @@ from shapely.geometry import box, Polygon
 logger = logging.getLogger(__name__)
 
 
-def create_new_raster_from_base(input_raster, output_raster, write_array):
+def create_new_raster_from_base(input_raster, output_raster, write_array, **kwargs):
     """Function to use info from input raster to create new one.
     Args:
         input_raster: input raster path and name
         output_raster: raster name and path to be created with info from input
         write_array (optional): array to write into the new raster
+        kwargs (optional): Complementary parameter(s)
 
     Return:
         none
@@ -61,6 +62,10 @@ def create_new_raster_from_base(input_raster, output_raster, write_array):
                        transform=src.transform,
                        compress='lzw') as dst:
         dst.write(write_array)
+        # add tag to transmit more informations
+        if 'checkpoint_path' in kwargs.keys():
+            # add the path to the model checkpoint
+            dst.update_tags(checkpoint=kwargs['checkpoint_path']) 
 
 
 def get_key_recursive(key, config):
@@ -235,8 +240,9 @@ def multi2poly(returned_vector_pred, layer_name=None):
     Args:
         returned_vector_pred: string, geopackage PATH where the post-processing
                               results are saved.
-        layer_name: string, the name of layer to look into for multipolygon, the name
+        layer_name (optional): string, the name of layer to look into for multipolygon, the name
                     represente the classes post-processed. Default None.
+                    
     Return:
         none
     """

--- a/utils/geoutils.py
+++ b/utils/geoutils.py
@@ -255,3 +255,27 @@ def multi2poly(returned_vector_pred, layer_name=None):
     except Exception as e:
         logging.error(f"\nSomething went wrong during the conversion of Polygon. \nError {type(e)}: {e}")
         
+        
+        
+def fetch_tag_raster(raster_path, tag_wanted):
+    """
+    Fetch the tag(s) information saved inside the tiff.
+    TODO, change the `tag_wanted` to accept str or list of str.
+    Args:
+        raster_path: string, raster path
+        tag_wanted: string, tag name, ex. 'checkpoint'
+    Return:
+        string containing associate information to the `tag_wanted`
+    """
+    with rasterio.open(raster_path) as tiff_src:
+        tags = tiff_src.tags()
+    # check if the tiff have a checkpoint save in 
+    if tag_wanted in tags.keys():
+        return tags[tag_wanted]
+    else:
+        raise logging.error(
+            f"\nThe tag {tag_wanted} was not found in the {list(tags.keys())},"
+            f" try again with one inside that list."
+        )
+    
+ 


### PR DESCRIPTION
New feature, function added in geoutils.py to fetch information save into tag inside a rasterio file. 
Also save checkpoint inside the inference raster at the end of `inference_segmentation.py`. This part is temporary, the tag information will be use via `create_new_raster_from_base` in the future.

This is necessary to tackle the #442 issue otherwise the GPKG will miss information.
