### PR TITLE
inference_segmentation.py: implement prep_data_only_mode

### DIFF
--- a/config/inference/default_binary.yaml
+++ b/config/inference/default_binary.yaml
@@ -7,6 +7,7 @@ inference:
   # Maximum number of pixels each Mb of GPU Ram to allow. E.g. if GPU has 1000 Mb of Ram and this parameter is set to
   # 10, chunk_size will be set to sqrt(1000 * 10) = 100.
   max_pix_per_mb_gpu: 25
+  prep_data_only: False
 
   # GPU parameters
   gpu: ${training.num_gpus}

--- a/config/inference/default_multiclass.yaml
+++ b/config/inference/default_multiclass.yaml
@@ -7,6 +7,7 @@ inference:
   # Maximum number of pixels each Mb of GPU Ram to allow. E.g. if GPU has 1000 Mb of Ram and this parameter is set to
   # 10, chunk_size will be set to sqrt(1000 * 10) = 100.
   max_pix_per_mb_gpu: 25
+  prep_data_only: False
 
   # GPU parameters
   gpu: ${training.num_gpus}

--- a/inference_segmentation.py
+++ b/inference_segmentation.py
@@ -359,6 +359,7 @@ def main(params: Union[DictConfig, dict]) -> None:
                                validate_path_exists=True)
     input_stac_item = get_key_def('input_stac_item', params['inference'], expected_type=str, to_path=True,
                                   validate_path_exists=True)
+    prep_data_only = get_key_def('prep_data_only', params['inference'], default=False, expected_type=bool)
 
     # LOGGING PARAMETERS
     exper_name = get_key_def('project_name', params['general'], default='gdl-training')
@@ -420,6 +421,10 @@ def main(params: Union[DictConfig, dict]) -> None:
         data_dir=data_dir,
         equalize_clahe_clip_limit=clahe_clip_limit,
     )
+
+    if prep_data_only:
+        logging.info(f"[prep_data_only mode] Data preparation for inference is complete. Exiting...")
+        exit()
 
     # LOOP THROUGH LIST OF INPUT IMAGES
     for aoi in tqdm(list_aois, desc='Inferring from images', position=0, leave=True):


### PR DESCRIPTION
fixes #363 
Prep data only mode: exits after creation of AOIs, i.e. after potential download of input data and enhancement of imagery