### PR TITLE
Resolving the raising error when `get_key_def` not match the expected type

### DIFF
--- a/inference_segmentation.py
+++ b/inference_segmentation.py
@@ -361,7 +361,7 @@ def main(params: Union[DictConfig, dict]) -> None:
     num_bands = len(bands_requested)
 
     # Default input directory based on default output directory
-    raw_data_csv = get_key_def('raw_data_csv', params['inference'], expected_type=str, to_path=True,
+    raw_data_csv = get_key_def('raw_data_csv', params['inference'], expected_type=Path, to_path=True,
                                validate_path_exists=True)
     input_stac_item = get_key_def('input_stac_item', params['inference'], expected_type=str, to_path=True,
                                   validate_path_exists=True)

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -2,13 +2,14 @@ import pytest
 from torchgeo.datasets.utils import extract_archive
 
 from hydra import initialize, compose
-from omegaconf import DictConfig, OmegaConf, open_dict
+from omegaconf import OmegaConf
+import unittest
 
 from models.model_choice import read_checkpoint
 from utils.utils import read_csv, is_inference_compatible, update_gdl_checkpoint, get_key_def
 
 
-class TestUtils(object):
+class TestUtils(unittest.TestCase):
     def test_wrong_seperation(self) -> None:
         extract_archive(src="tests/data/spacenet.zip")
         with pytest.raises(TypeError):

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -4,6 +4,7 @@ from torchgeo.datasets.utils import extract_archive
 from hydra import initialize, compose
 from omegaconf import OmegaConf
 import unittest
+from hydra.core.hydra_config import HydraConfig
 
 from models.model_choice import read_checkpoint
 from utils.utils import read_csv, is_inference_compatible, update_gdl_checkpoint, get_key_def
@@ -51,9 +52,10 @@ class TestUtils(unittest.TestCase):
         assert ckpt_updated['params']['augmentation']['clahe_enhance_clip_limit'] == 0.1
 
     def test_expected_type_get_key_def(self) -> None:
-        with initialize(config_path="../../config", job_name="test_ci"):
+        with initialize(config_path="../../config", job_name="test_key_def"):
             cfg = compose(config_name="gdl_config_template")
-            cfg = OmegaConf.create(cfg)
+            hconf = HydraConfig()
+            hconf.set_config(cfg)
             # Not the same type - raise the error
             with self.assertRaises(TypeError):
                 get_key_def('max_pix_per_mb_gpu', cfg['inference'], default=25, expected_type=str)

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -56,9 +56,9 @@ class TestUtils(unittest.TestCase):
             cfg = OmegaConf.create(cfg)
             # Not the same type - raise the error
             with self.assertRaises(TypeError):
-                get_key_def('max_pix_per_mb_gpu', params['inference'], default=25, expected_type=str)
+                get_key_def('max_pix_per_mb_gpu', cfg['inference'], default=25, expected_type=str)
             # Same type
-            mp = get_key_def('max_pix_per_mb_gpu', params['inference'], default=25, expected_type=int)
+            mp = get_key_def('max_pix_per_mb_gpu', cfg['inference'], default=25, expected_type=int)
             assert isinstance(mp, int)
             
         

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -53,7 +53,7 @@ class TestUtils(unittest.TestCase):
 
     def test_expected_type_get_key_def(self) -> None:
         with initialize(config_path="../../config", job_name="test_key_def"):
-            cfg = compose(config_name="gdl_config_template")
+            cfg = compose(config_name="gdl_config_template", return_hydra_config=True)
             hconf = HydraConfig()
             hconf.set_config(cfg)
             # Not the same type - raise the error

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -162,10 +162,9 @@ def get_key_def(key, config, default=None, expected_type=None, to_path: bool = F
             pass
         else:
             val = config[key] if config[key] != 'None' else None
-            if expected_type and val is not False:
-                if not isinstance(val, expected_type):
-                    raise TypeError(f"{val} is of type {type(val)}, expected {expected_type}")
+            
     if not val:  # Skips below if statements if val is None
+        logging.error(f"The key {key} as a None value.")
         return val
     if is_url(val):
         logging.info(f"\nProvided path is url. Cannot validate it's existence nor convert to Path object. Got:"
@@ -189,6 +188,10 @@ def get_key_def(key, config, default=None, expected_type=None, to_path: bool = F
         if not val.exists():
             logging.critical(f"Couldn't locate path: {val}.\nProvided key: {key}")
             raise FileNotFoundError()
+
+    if expected_type and val is not False:
+        if not isinstance(val, expected_type):
+            raise TypeError(f"{val} is of type {type(val)}, expected {expected_type}")
 
     return val
 


### PR DESCRIPTION
Fix #476 by moving the exception at the end of the function and adding a test to the mix.