### PR TITLE
Inference: implement user-chosen output path

### DIFF
--- a/config/inference/README.md
+++ b/config/inference/README.md
@@ -28,6 +28,9 @@ Path to checkpoint containing trained weights for a given neural network archite
 Complete path including parent directories and full name with extension where output inference should be saved.
 Default: root_dir / {aoi.aoi_id}_pred.tif (see [AOI documentation](../../dataset/README.md#input-data))
 
+> the "output_path" parameter should only be used if a single inference is being performed. Otherwise, it is recommended
+> to set the root_dir and use the default output name.  
+
 ## checkpoint_dir (str)
 
 Directory in which to save the checkpoint file if url.

--- a/config/inference/README.md
+++ b/config/inference/README.md
@@ -4,6 +4,10 @@
 
 > Input imagery should be either a csv of stac item
 
+### root_dir (str)
+
+Directory where outputs and downloads will be written by default, if "checkpoint_dir" or "output_path" are omitted.
+
 ### raw_data_csv (str)
 
 Points to a csv containing paths to imagery for inference. If a ground truth is present in 2nd column, it will be 
@@ -18,6 +22,15 @@ also contained in [test data](../../tests/data/spacenet.zip).
 ### state_dict_path (str)
 
 Path to checkpoint containing trained weights for a given neural network architecture.
+
+## output_path (str, optional)
+
+Complete path including parent directories and full name with extension where output inference should be saved.
+Default: root_dir / {aoi.aoi_id}_pred.tif (see [AOI documentation](../../dataset/README.md#input-data))
+
+## checkpoint_dir (str)
+
+Directory in which to save the checkpoint file if url.
 
 ## chunk_size (int)
 

--- a/config/inference/default_binary.yaml
+++ b/config/inference/default_binary.yaml
@@ -4,6 +4,7 @@ inference:
   root_dir: inferences
   input_stac_item:  # alternatively, use a path or url to stac item directly
   state_dict_path: ${general.save_weights_dir}/
+  output_path:
   checkpoint_dir: ${general.save_weights_dir}  # (string, optional): directory in which to save the object if url
   chunk_size:  # if empty, will be calculated automatically from max_pix_per_mb_gpu
   # Maximum number of pixels each Mb of GPU Ram to allow. E.g. if GPU has 1000 Mb of Ram and this parameter is set to

--- a/config/inference/default_multiclass.yaml
+++ b/config/inference/default_multiclass.yaml
@@ -4,6 +4,7 @@ inference:
   root_dir: inferences
   input_stac_item:  # alternatively, use a path or url to stac item directly
   state_dict_path: ${general.save_weights_dir}/
+  output_path:
   checkpoint_dir: ${general.save_weights_dir}  # (string, optional): directory in which to save the object if url
   chunk_size:  # if empty, will be calculated automatically from max_pix_per_mb_gpu
   # Maximum number of pixels each Mb of GPU Ram to allow. E.g. if GPU has 1000 Mb of Ram and this parameter is set to

--- a/dataset/README.md
+++ b/dataset/README.md
@@ -13,8 +13,7 @@ terms, to be an [AOI](https://torchgeo.readthedocs.io/en/latest/user/glossary.ht
 | my_dir/my_geoimagery2.tif | my_dir/my_geogt2.gpkg    | tst           | NewBrunswick-23   |
 | ...                       | ...                      | ...           | ...               |
 
-> The use of aoi id information will be implemented in a near future. It will serve, for example, to print a detailed 
-> report of tiling, training and evaluation, or for easier debugging.
+> If left blank, the aoi id will be derived from the raster path and bands requested.
 
 The path to a custom csv must be entered in the 
 [dataset configuration](../config/dataset/test_ci_segmentation_binary.yaml). See the 

--- a/inference_segmentation.py
+++ b/inference_segmentation.py
@@ -469,7 +469,7 @@ def main(params: Union[DictConfig, dict]) -> None:
                          "count": pred_heatmap.shape[0],
                          "dtype": 'uint8',
                          "compress": 'lzw'})
-        logging.info(f'\nSuccessfully inferred on {aoi.aoi_id}\nWriting to file: {inference_image}')
+        logging.info(f'\nSuccessfully inferred on {aoi.aoi_id}\nWriting to file: {output_path}')
 
         pred_img = class_from_heatmap(heatmap_arr=pred_heatmap, heatmap_threshold=heatmap_threshold)
 
@@ -487,7 +487,7 @@ def main(params: Union[DictConfig, dict]) -> None:
 
         create_new_raster_from_base(
             input_raster=aoi.raster,
-            output_raster=inference_image,
+            output_raster=output_path,
             write_array=pred_img,
             checkpoint_path=state_dict
             )
@@ -501,6 +501,6 @@ def main(params: Union[DictConfig, dict]) -> None:
             start_vec = time.time()
             inference_vec = working_folder.joinpath(aoi.raster_name.parent.name,
                                                     f"{aoi.raster_name.split('.')[0]}_inference.gpkg")
-            ras2vec(inference_image, inference_vec)
+            ras2vec(output_path, inference_vec)
             end_vec = time.time() - start_vec
             logging.info('Vectorization completed in {:.0f}m {:.0f}s'.format(end_vec // 60, end_vec % 60))


### PR DESCRIPTION
fixes #472 (oups the PR branch has wrong number!)
inference_segmentation.py:
- implement output_path and name heatmap and temp file accordingly
- replace aoi.raster_name to aoi.aoi_id for cleaner log README.md: update inference and aoi READMEs
default_binary.yaml: add output_path
default_multiclass.yaml: idem
