### PR TITLE
utils.py/get_key_def(): allow "expected_type=str" even with "to_path=True" param

### DIFF
--- a/evaluate_segmentation.py
+++ b/evaluate_segmentation.py
@@ -93,7 +93,7 @@ def main(params):
 
     # benchmark (ie when gkpgs are inputted along with imagery)
     out_gpkg = get_key_def('out_benchmark_gpkg', params['inference'], default=working_folder/"benchmark.gpkg",
-                           expected_type=str)
+                           expected_type=str, to_path=True)
     chunk_size = get_key_def('chunk_size', params['inference'], default=512, expected_type=int)
     dontcare = get_key_def("ignore_index", params["dataset"], -1)
     attribute_field = get_key_def('attribute_field', params['dataset'], None, expected_type=str)

--- a/evaluate_segmentation.py
+++ b/evaluate_segmentation.py
@@ -80,6 +80,8 @@ def main(params):
     state_dict = get_key_def('state_dict_path', params['inference'], to_path=True,
                              validate_path_exists=True,
                              wildcard='*pth.tar')
+    inference_image = get_key_def(key='output_path', config=params['inference'], to_path=True, expected_type=str)
+
     bands_requested = get_key_def('bands', params['dataset'], default=[], expected_type=Sequence)
     num_bands = len(bands_requested)
     working_folder = get_key_def('root_dir', params['inference'], default="inference", to_path=True)
@@ -107,6 +109,10 @@ def main(params):
 
     list_aois = aois_from_csv(csv_path=raw_data_csv, bands_requested=bands_requested)
 
+    if len(list_aois) > 1 and inference_image:
+        raise ValueError(f"\n\"inference.output_path\" should be set for a single evaluation only. \n"
+                         f"Got {len(list_aois)} AOIs for evaluation.\n")
+
     # VALIDATION: anticipate problems with imagery and label (if provided) before entering main for loop
     for aoi in tqdm(list_aois, desc='Validating ground truth'):
         if aoi.label is None:
@@ -118,12 +124,12 @@ def main(params):
     gpkg_name_ = []
 
     for aoi in tqdm(list_aois, desc='Evaluating from input list', position=0, leave=True):
-        inference_image = working_folder / f"{aoi.raster_name.stem}_inference.tif"
-        if not inference_image.is_file():
-            raise FileNotFoundError(f"Couldn't locate inference to evaluate metrics with. Make inferece has been run "
+        output_path = working_folder / f"{aoi.aoi_id}_pred.tif" if not inference_image else inference_image
+        if not output_path.is_file():
+            raise FileNotFoundError(f"Couldn't locate inference to evaluate metrics with. Make inference has been run "
                                     f"before you run evaluate mode.")
 
-        pred = rasterio.open(inference_image).read()[0, ...]
+        pred = rasterio.open(output_path).read()[0, ...]
 
         logging.info(f'\nBurning label as raster: {aoi.label}')
         raster = rasterio.open(aoi.raster_name, 'r')

--- a/inference_segmentation.py
+++ b/inference_segmentation.py
@@ -340,7 +340,7 @@ def main(params: Union[DictConfig, dict]) -> None:
     state_dict = get_key_def('state_dict_path', params['inference'], to_path=True,
                              validate_path_exists=True,
                              wildcard='*pth.tar')
-    inference_image = get_key_def(key='output_path', config=params['inference'], to_path=True, expected_type=Path)
+    inference_image = get_key_def(key='output_path', config=params['inference'], to_path=True, expected_type=str)
     if inference_image:
         inference_image.parent.mkdir(exist_ok=True)
 
@@ -364,7 +364,7 @@ def main(params: Union[DictConfig, dict]) -> None:
     num_bands = len(bands_requested)
 
     # Default input directory based on default output directory
-    raw_data_csv = get_key_def('raw_data_csv', params['inference'], expected_type=Path, to_path=True,
+    raw_data_csv = get_key_def('raw_data_csv', params['inference'], expected_type=str, to_path=True,
                                validate_path_exists=True)
     input_stac_item = get_key_def('input_stac_item', params['inference'], expected_type=str, to_path=True,
                                   validate_path_exists=True)

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 from torchgeo.datasets.utils import extract_archive
 
@@ -62,5 +64,11 @@ class TestUtils(unittest.TestCase):
             # Same type
             mp = get_key_def('max_pix_per_mb_gpu', cfg['inference'], default=25, expected_type=int)
             assert isinstance(mp, int)
+            # with to_path=True, two different possibilities for expected type: str or Path
+            assert isinstance(cfg['inference']['raw_data_csv'], str)
+            mp = get_key_def('raw_data_csv', cfg['inference'], expected_type=Path, to_path=True)
+            assert isinstance(mp, Path)
+            mp = get_key_def('raw_data_csv', cfg['inference'], expected_type=str, to_path=True)
+            assert isinstance(mp, Path)
             
         

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -175,6 +175,7 @@ def get_key_def(key, config, default=None, expected_type=None, to_path: bool = F
             val = Path(to_absolute_path(val))
         except TypeError:
             logging.error(f"Couldn't convert value {val} to a pathlib.Path object")
+        expected_type = Path if expected_type == "str" else expected_type  # allows "str" and "Path" as expected_type
     if validate_path_exists:
         if not isinstance(val, Path):
             val = Path(to_absolute_path(val))

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -175,7 +175,7 @@ def get_key_def(key, config, default=None, expected_type=None, to_path: bool = F
             val = Path(to_absolute_path(val))
         except TypeError:
             logging.error(f"Couldn't convert value {val} to a pathlib.Path object")
-        expected_type = Path if expected_type == "str" else expected_type  # allows "str" and "Path" as expected_type
+        expected_type = Path if expected_type == str else expected_type  # allows "str" and "Path" as expected_type
     if validate_path_exists:
         if not isinstance(val, Path):
             val = Path(to_absolute_path(val))


### PR DESCRIPTION
inference_segmentation.py: restore str as expected type to better reflect documentation

Documentation for "expected_type" in get_key_def(): [:param expected_type: (type) type of the expected variable.](https://github.com/NRCan/geo-deep-learning/blob/develop/utils/utils.py#L142)

To me, this suggests that the input variable must bear this "expected_type". It feels confusing to expected a type that is actually one that is assigned during the get_key_def() function, "Path" in this case.
@CharlesAuthier is this slight retroactive change ok to you?