### PR TITLE
geoutils.py: force BIGTIFF

### DIFF
--- a/inference_segmentation.py
+++ b/inference_segmentation.py
@@ -172,7 +172,7 @@ def segmentation(param,
     img_gen = gen_img_samples(src=input_image, patch_list=patch_list, chunk_size=chunk_size)
     single_class_mode = False if num_classes > 1 else True
     for sub_image, h_idxs, w_idxs, hann_win in tqdm(
-        img_gen, position=0, leave=True, desc='Inferring on patches',
+        img_gen, position=0, leave=True, desc=f'Inferring on patches',
         total=len(patch_list)
     ):
         hann_win = np.expand_dims(hann_win, -1)

--- a/inference_segmentation.py
+++ b/inference_segmentation.py
@@ -172,7 +172,7 @@ def segmentation(param,
     img_gen = gen_img_samples(src=input_image, patch_list=patch_list, chunk_size=chunk_size)
     single_class_mode = False if num_classes > 1 else True
     for sub_image, h_idxs, w_idxs, hann_win in tqdm(
-        img_gen, position=0, leave=True, desc=f'Inferring on patches',
+        img_gen, position=0, leave=True, desc='Inferring on patches',
         total=len(patch_list)
     ):
         hann_win = np.expand_dims(hann_win, -1)

--- a/utils/geoutils.py
+++ b/utils/geoutils.py
@@ -65,6 +65,10 @@ def create_new_raster_from_base(input_raster, output_raster, write_array, dtype 
                        crs=src.crs,
                        dtype=dtype,
                        transform=src.transform,
+                       tiled=True,
+                       blockxsize=256,
+                       blockysize=256,
+                       BIGTIFF='YES',
                        compress='lzw') as dst:
         dst.write(write_array)
         # add tag to transmit more information


### PR DESCRIPTION
fixes #525 

In the [GDAL doc](https://gdal.org/drivers/raster/gtiff.html), nothing seems problematic with always writing BIGTIFF. The only requirement is to have libtiff > 4.0, which has also been the case in our conda envs. I check all our conda envs and docker images and they all include libtiff >4.0.

This solution also uses tiled=True and defines blocksizes in the tif, as suggested by [this SO post](https://gis.stackexchange.com/questions/347765/how-to-write-bigtiff-raster-files-with-rasterio).