### PR TITLE
Override steps as epoch in Mlflow logger

### DIFF
--- a/configs/dofa_config_RGB.yaml
+++ b/configs/dofa_config_RGB.yaml
@@ -12,7 +12,7 @@ trainer:
   precision: "16-mixed"
   sync_batchnorm: true
   logger:
-    class_path: lightning.pytorch.loggers.mlflow.MLFlowLogger
+    class_path: tools.loggers.overrideStepEpochsMlflowLogger.OverrideStepEpochsMlflowLogger
     init_args:
       save_dir: /home/valhassa/Projects/geo-deep-learning/logs
       log_model: all
@@ -39,6 +39,9 @@ trainer:
         data_type_max: ${data.init_args.data_type_max}
         num_classes: ${model.init_args.num_classes}
         class_colors: ${model.init_args.class_colors}
+    - class_path: tools.callbacks.overrideEpochStepsCallback.OverrideEpochStepCallback
+      init_args:
+        override: true
   max_epochs: 10
 
 model:

--- a/configs/segformer_config_RGB.yaml
+++ b/configs/segformer_config_RGB.yaml
@@ -13,7 +13,7 @@ trainer:
   precision: "16-mixed"
   sync_batchnorm: true
   logger:
-    class_path: lightning.pytorch.loggers.mlflow.MLFlowLogger
+    class_path: tools.loggers.overrideStepEpochsMlflowLogger.OverrideStepEpochsMlflowLogger
     init_args:
       save_dir: /home/valhassa/Projects/geo-deep-learning/logs
       log_model: all
@@ -40,6 +40,9 @@ trainer:
         data_type_max: ${data.init_args.data_type_max}
         num_classes: ${model.init_args.num_classes}
         class_colors: ${model.init_args.class_colors}
+    - class_path: tools.callbacks.overrideEpochStepsCallback.OverrideEpochStepCallback
+      init_args:
+        override: true
   max_epochs: 10
 
 model:

--- a/configs/unetplus_config_RGB.yaml
+++ b/configs/unetplus_config_RGB.yaml
@@ -7,7 +7,7 @@ trainer:
   precision: "16-mixed"
   sync_batchnorm: true
   logger:
-    class_path: lightning.pytorch.loggers.mlflow.MLFlowLogger
+    class_path: tools.loggers.overrideStepEpochsMlflowLogger.OverrideStepEpochsMlflowLogger
     init_args:
       save_dir: /home/valhassa/Projects/geo-deep-learning/logs
       log_model: all
@@ -34,6 +34,9 @@ trainer:
         data_type_max: ${data.init_args.data_type_max}
         num_classes: ${model.init_args.num_classes}
         class_colors: ${model.init_args.class_colors}
+    - class_path: tools.callbacks.overrideEpochStepsCallback.OverrideEpochStepCallback
+      init_args:
+        override: true
   max_epochs: 150
 
 model:

--- a/geo_deep_learning/tools/callbacks/overrideEpochStepsCallback.py
+++ b/geo_deep_learning/tools/callbacks/overrideEpochStepsCallback.py
@@ -1,0 +1,22 @@
+from lightning.pytorch.callbacks import Callback
+from lightning.pytorch import Trainer, LightningModule
+
+class OverrideEpochStepCallback(Callback):
+    def __init__(self, override = True) -> None:
+        super().__init__()
+        self.override = override
+
+    def on_train_epoch_end(self, trainer: Trainer, pl_module: LightningModule):
+        if self.override:
+            self._log_step_as_current_epoch(trainer, pl_module)
+
+    def on_test_epoch_end(self, trainer: Trainer, pl_module: LightningModule):
+        if self.override:
+            self._log_step_as_current_epoch(trainer, pl_module)
+
+    def on_validation_epoch_end(self, trainer: Trainer, pl_module: LightningModule):
+        if self.override:
+            self._log_step_as_current_epoch(trainer, pl_module)
+
+    def _log_step_as_current_epoch(self, trainer: Trainer, pl_module: LightningModule):
+        pl_module.log("step", int(trainer.current_epoch), sync_dist=True)

--- a/geo_deep_learning/tools/loggers/overrideStepEpochsMlflowLogger.py
+++ b/geo_deep_learning/tools/loggers/overrideStepEpochsMlflowLogger.py
@@ -1,0 +1,10 @@
+from lightning.pytorch.loggers import MLFlowLogger
+
+class OverrideStepEpochsMlflowLogger(MLFlowLogger):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def log_metrics(self, metrics, step=None):
+        if step is not None:
+            step = int(step)
+        super().log_metrics(metrics, step)


### PR DESCRIPTION
# Description

Currently, there is a heated debate in the PytorchLightning community on the appropriate behavior of logging
`onStep=False` and `onEpoch=True` metrics. These metrics will be logged with based on the global step unit for the x-axis, which complicates the data analysis when using a logger such as mlflow to interpret metrics. The goal of this PR is to implement a workaround found by the community to override the step metrics so it is based on epochs instead, allowing a better understanding of the behavior of the model, regardless of batchsize.

here is the [original issue](https://github.com/Lightning-AI/pytorch-lightning/issues/3228)

## Type of change
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other 

## How Has This Been Tested?
If the added changes are already cover by tests, skip that section.
Otherwise, please describe tests that you added to the pytest codebase (if applicable).

this was tested locally on a different model, but should work correctly on the others too

## Screenshots (if applicable):

# Checklist:
If you're unsure about any of these, don't hesitate to ask. We're here to help! 
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] My PR has a descriptive title
- [ ] My code follows PEP8 (most of it)
- [ ] My code have the proper documentation in the code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new errors
- [ ] My code is covered by the existing tests (if applicable)
- [ ] My code includes tests that show that my feature works
- [ ] My PR passes Travis CI tests


_If your PR does not fulfill all of the requirements in the checklist above, that's OK!_ If you need help, @-mention a maintainer and/or add the __Status: Help Needed__ label.